### PR TITLE
ci: cancel auto-release if a PR already exists

### DIFF
--- a/.github/actions/auto-patch-release-v1/action.yml
+++ b/.github/actions/auto-patch-release-v1/action.yml
@@ -34,7 +34,7 @@ runs:
     - name: Cancel if we already have a PR
       uses: dequelabs/axe-api-team-public/.github/actions/cancel-if-release-pr-exists
       with:
-        token: ${{ inputs.project_token }}
+        token: ${{ inputs.token }}
     - name: Exit early if odd numbered week
       shell: bash
       run: |

--- a/.github/actions/auto-patch-release-v1/action.yml
+++ b/.github/actions/auto-patch-release-v1/action.yml
@@ -26,6 +26,10 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Cancel if we already have a PR
+      uses: dequelabs/axe-api-team-public/.github/actions/cancel-if-release-pr-exists
+      with:
+        token: ${{ inputs.project_token }}
     - name: Checkout repo
       uses: actions/checkout@v3
       with:

--- a/.github/actions/auto-patch-release-v1/action.yml
+++ b/.github/actions/auto-patch-release-v1/action.yml
@@ -26,15 +26,15 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Cancel if we already have a PR
-      uses: dequelabs/axe-api-team-public/.github/actions/cancel-if-release-pr-exists
-      with:
-        token: ${{ inputs.project_token }}
     - name: Checkout repo
       uses: actions/checkout@v3
       with:
         token: ${{ inputs.token }}
         fetch-depth: 0
+    - name: Cancel if we already have a PR
+      uses: dequelabs/axe-api-team-public/.github/actions/cancel-if-release-pr-exists
+      with:
+        token: ${{ inputs.project_token }}
     - name: Exit early if odd numbered week
       shell: bash
       run: |

--- a/.github/actions/cancel-if-release-pr-exists/action.yml
+++ b/.github/actions/cancel-if-release-pr-exists/action.yml
@@ -1,0 +1,21 @@
+name: Cancel if Release PR Exists
+description: Cancel the parent workflow if a release PR exists a release PR exists
+inputs:
+  token:
+    required: true
+    type: string
+runs:
+  using: "composite"
+  steps:
+    - name: Exit early if release PR exists
+      shell: bash
+      run: |
+        # -z returns true if the string is empty.
+        # If no PRs are found, `gh pr list` will be empty.
+        if [ ! -z "$(gh pr list --label release)" ]; then
+          echo "Odd numbered week. Skipping";
+          gh run cancel ${{ github.run_id }};
+          gh run watch ${{ github.run_id }};
+        fi
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}

--- a/.github/actions/cancel-if-release-pr-exists/action.yml
+++ b/.github/actions/cancel-if-release-pr-exists/action.yml
@@ -7,13 +7,15 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # Note: Must have repo checked out to use this action
     - name: Exit early if release PR exists
       shell: bash
       run: |
         # -z returns true if the string is empty.
         # If no PRs are found, `gh pr list` will be empty.
         if [ ! -z "$(gh pr list --label release)" ]; then
-          echo "Odd numbered week. Skipping";
+          echo "Found release PR. Cancelling this workflow.";
+          gh pr list --label release;
           gh run cancel ${{ github.run_id }};
           gh run watch ${{ github.run_id }};
         fi


### PR DESCRIPTION
Tested on devtools-pip

Action when there was a release PR: https://github.com/dequelabs/axe-devtools-pip/actions/runs/5413935143
Action when no open release PRs: https://github.com/dequelabs/axe-devtools-pip/actions/runs/5413958185/jobs/9840298492