### PR TITLE
ci(auto-patch): fix date check

### DIFF
--- a/.github/actions/auto-patch-release-v1/action.yml
+++ b/.github/actions/auto-patch-release-v1/action.yml
@@ -41,7 +41,9 @@ runs:
         echo or = $ODD_RELEASE
         which date
         date +%U
-        weekIsEven="$(expr $(date +%U) % 2)"
+        weekOfYear="$(date +%U)"
+        echo woy = $weekOfYear
+        weekIsEven="$(expr $weekOfYear % 2)"
         echo wie = $weekIsEven
         if [ "$ODD_RELEASE" = "true" ]; then
           target_mod=1;

--- a/.github/actions/auto-patch-release-v1/action.yml
+++ b/.github/actions/auto-patch-release-v1/action.yml
@@ -38,17 +38,21 @@ runs:
     - name: Exit early if odd numbered week
       shell: bash
       run: |
+        echo or = $ODD_RELEASE
         weekIsEven="$(expr $(date +%U) % 2)"
+        echo wie = $weekIsEven
         if [ "$ODD_RELEASE" = "true" ]; then
           target_mod=1;
         else
           target_mod=0;
         fi
+        echo target_mod = $target_mod
         if [ "$weekIsEven" -eq "$target_mod" ]; then
           echo "Odd numbered week. Skipping";
           gh run cancel ${{ github.run_id }};
           gh run watch ${{ github.run_id }};
         fi
+        echo done
       env:
         ODD_RELEASE: ${{ inputs.odd_release }}
         GITHUB_TOKEN: ${{ inputs.token }}

--- a/.github/actions/auto-patch-release-v1/action.yml
+++ b/.github/actions/auto-patch-release-v1/action.yml
@@ -29,7 +29,7 @@ runs:
     - name: Checkout repo
       uses: actions/checkout@v3
       with:
-        ref: ${{ default-branch }}
+        ref: ${{ inputs.default-branch }}
         token: ${{ inputs.token }}
         fetch-depth: 0
     - name: Cancel if we already have a PR

--- a/.github/actions/auto-patch-release-v1/action.yml
+++ b/.github/actions/auto-patch-release-v1/action.yml
@@ -39,6 +39,8 @@ runs:
       shell: bash
       run: |
         echo or = $ODD_RELEASE
+        which date
+        date +%U
         weekIsEven="$(expr $(date +%U) % 2)"
         echo wie = $weekIsEven
         if [ "$ODD_RELEASE" = "true" ]; then

--- a/.github/actions/auto-patch-release-v1/action.yml
+++ b/.github/actions/auto-patch-release-v1/action.yml
@@ -45,7 +45,7 @@ runs:
         echo woy = $weekOfYear
         expr $weekOfYear % 2
         echo getting and storing even
-        weekIsEven="$(expr $weekOfYear % 2)"
+        weekIsEven="$(bash -c 'expr $weekOfYear % 2')"
         echo wie = $weekIsEven
         if [ "$ODD_RELEASE" = "true" ]; then
           target_mod=1;

--- a/.github/actions/auto-patch-release-v1/action.yml
+++ b/.github/actions/auto-patch-release-v1/action.yml
@@ -38,28 +38,18 @@ runs:
     - name: Exit early if odd numbered week
       shell: bash
       run: |
-        echo or = $ODD_RELEASE
-        which date
-        date +%U
         weekOfYear="$(date +%U)"
-        echo woy = $weekOfYear
-        expr $weekOfYear % 2
-        echo getting and storing even
-        echo WHYYYYYYYYYYYY
-        weekIsEven="$(expr $weekOfYear % 2)"
-        echo wie = $weekIsEven
+        weekIsEven="$(($weekOfYear % 2))"
         if [ "$ODD_RELEASE" = "true" ]; then
           target_mod=1;
         else
           target_mod=0;
         fi
-        echo target_mod = $target_mod
         if [ "$weekIsEven" -eq "$target_mod" ]; then
           echo "Odd numbered week. Skipping";
           gh run cancel ${{ github.run_id }};
           gh run watch ${{ github.run_id }};
         fi
-        echo done
       env:
         ODD_RELEASE: ${{ inputs.odd_release }}
         GITHUB_TOKEN: ${{ inputs.token }}

--- a/.github/actions/auto-patch-release-v1/action.yml
+++ b/.github/actions/auto-patch-release-v1/action.yml
@@ -43,6 +43,8 @@ runs:
         date +%U
         weekOfYear="$(date +%U)"
         echo woy = $weekOfYear
+        expr $weekOfYear % 2
+        echo getting and storing even
         weekIsEven="$(expr $weekOfYear % 2)"
         echo wie = $weekIsEven
         if [ "$ODD_RELEASE" = "true" ]; then

--- a/.github/actions/auto-patch-release-v1/action.yml
+++ b/.github/actions/auto-patch-release-v1/action.yml
@@ -45,7 +45,8 @@ runs:
         echo woy = $weekOfYear
         expr $weekOfYear % 2
         echo getting and storing even
-        weekIsEven="$(bash -c 'expr $weekOfYear % 2')"
+        echo WHYYYYYYYYYYYY
+        weekIsEven="$(expr $weekOfYear % 2)"
         echo wie = $weekIsEven
         if [ "$ODD_RELEASE" = "true" ]; then
           target_mod=1;

--- a/.github/actions/auto-patch-release-v1/action.yml
+++ b/.github/actions/auto-patch-release-v1/action.yml
@@ -29,6 +29,7 @@ runs:
     - name: Checkout repo
       uses: actions/checkout@v3
       with:
+        ref: ${{ default-branch }}
         token: ${{ inputs.token }}
         fetch-depth: 0
     - name: Cancel if we already have a PR


### PR DESCRIPTION
``` 
The expr utility exits with one of the following values:
 0       the expression is neither an empty string nor 0.
 1       the expression is an empty string or 0.
 2       the expression is invalid.
```

Why

The date code was tested in a local bash script then copy-pasted into the action. Said script didn't have exit-on-error, so this behavior was not found.

Also fixes an issue found when running on axe-core-npm's release script