### PR TITLE
chore: add `CODEOWNERS` file

### DIFF
--- a/.github/chore: add `CODEOWNERS` file
+++ b/.github/chore: add `CODEOWNERS` file
@@ -1,0 +1,1 @@
+* @dequelabs/axe-api-team


### PR DESCRIPTION
I was wondering why I wasn't getting any GH notifications when PR's were getting created here. Added code owners so we get notified