### PR TITLE
ci: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 
 updates:
-  - package-ecosystem: 'yarn'
+  - package-ecosystem: 'npm'
     directory: '/'
     schedule:
       interval: 'monthly'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  - package-ecosystem: 'yarn'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    groups:
+      non-breaking:
+        update-types:
+          - 'minor'
+          - 'patch'


### PR DESCRIPTION
This PR sets up the repository for automatic dependency updates and groups minor/patch in 1 PR and major versions in individual PR's for review.


Example YML file: https://github.com/Zidious/axe-api-team-public/blob/main/.github/dependabot.yml
Example result: https://github.com/Zidious/axe-api-team-public/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc



Ref: https://github.com/dequelabs/axe-api-team/issues/399