### PR TITLE
chore: add prebuild step to delete dist

### DIFF
--- a/.github/actions/add-to-board-v1/package.json
+++ b/.github/actions/add-to-board-v1/package.json
@@ -12,6 +12,7 @@
     "url": "git+https://github.com/dequelabs/axe-api-team-public.git"
   },
   "scripts": {
+    "prebuild": "rimraf dist",
     "build": "ncc build src/index.ts --license ../../../licenses.txt",
     "test": "mocha src/*.test.ts",
     "coverage": "nyc npm run test",

--- a/.github/actions/generate-commit-list-v1/package.json
+++ b/.github/actions/generate-commit-list-v1/package.json
@@ -12,6 +12,7 @@
     "url": "git+https://github.com/dequelabs/axe-api-team-public.git"
   },
   "scripts": {
+    "prebuild": "rimraf dist",
     "build": "ncc build src/index.ts --license ../../../licenses.txt",
     "test": "mocha src/*.test.ts",
     "coverage": "nyc npm run test",

--- a/.github/actions/has-auto-releasable-commits-v1/package.json
+++ b/.github/actions/has-auto-releasable-commits-v1/package.json
@@ -12,6 +12,7 @@
     "url": "git+https://github.com/dequelabs/axe-api-team-public.git"
   },
   "scripts": {
+    "prebuild": "rimraf dist",
     "build": "ncc build src/index.ts --license ../../../licenses.txt",
     "test": "mocha src/*.test.ts",
     "coverage": "nyc npm run test",

--- a/.github/actions/is-release-week-v1/package.json
+++ b/.github/actions/is-release-week-v1/package.json
@@ -13,6 +13,7 @@
   },
   "homepage": "https://github.com/dequelabs/axe-api-team-public#readme",
   "scripts": {
+    "prebuild": "rimraf dist",
     "build": "ncc build src/index.ts --license ../../../licenses.txt",
     "test": "mocha src/*.test.ts",
     "coverage": "nyc npm run test",

--- a/.github/actions/semantic-pr-footer-v1/package.json
+++ b/.github/actions/semantic-pr-footer-v1/package.json
@@ -13,6 +13,7 @@
   },
   "homepage": "https://github.com/dequelabs/axe-api-team-public#readme",
   "scripts": {
+    "prebuild": "rimraf dist",
     "build": "ncc build src/index.ts --license ../../../licenses.txt",
     "test": "mocha src/*.test.ts",
     "coverage": "nyc npm run test",


### PR DESCRIPTION
Husky calls `npm run build -ws` which should then call the prebuild step in all repos. I don't think we can use formatter action due to [this comment in the formatter action](https://github.com/dequelabs/axe-core/blob/develop/.github/workflows/format.yml#L23-L25):

> Workflows are not allowed to edit workflows. As result, we need to prevent Prettier from formatting them.

Closes: #28

No QA required