### PR TITLE
fix: use correct token in create-project-issue composite actions

### DIFF
--- a/.github/actions/create-project-issue-v1/action.yml
+++ b/.github/actions/create-project-issue-v1/action.yml
@@ -42,7 +42,7 @@ runs:
       uses: dacbd/create-issue-action@ba4d1c45cccf9c483f2720cefb40e437f0ee6f7d
       id: create_issue
       with:
-        token: ${{ github.token }}
+        token: ${{ inputs.token }}
         title: ${{ inputs.title }}
         body: ${{ inputs.body }}
         repo: ${{ inputs.repo }}


### PR DESCRIPTION
Causing the action to 404 when attempting to create issue cross repo 

https://github.com/dequelabs/zidious-testing/actions/runs/6423572944/job/17442362207#step:3:93

No QA Required