### PR TITLE
fix(.github/actions/create-project-issue-v1): emit outputs from composite action

### DIFF
--- a/.github/actions/create-project-issue-v1/README.md
+++ b/.github/actions/create-project-issue-v1/README.md
@@ -16,6 +16,12 @@ A GitHub Action to create a new issue and move the issue to a specific column on
 | `repo`           | The repository to create the issue in e.g. if the repository is under dequelabs/axe-core-npm, then supply "axe-core-npm"           | No       | `github.context.repo.repo`  |
 | `owner`          | The owner of the repository to create the issue in e.g. if the repository is under dequelabs/axe-core-npm, then supply "dequelabs" | No       | `github.context.repo.owner` |
 
+## Outputs
+
+| Name        | Description                  |
+| ----------- | ---------------------------- |
+| `issue_url` | The URL of the created issue |
+
 ## Example usage
 
 ```yaml

--- a/.github/actions/create-project-issue-v1/action.yml
+++ b/.github/actions/create-project-issue-v1/action.yml
@@ -1,5 +1,6 @@
 name: create-project-issue
 description: 'A GitHub Action to create a new issue and move the issue to a specific column on a project board'
+
 inputs:
   token:
     description: 'The GitHub token to use for authentication'
@@ -33,6 +34,13 @@ inputs:
     description: 'The column name to create the issue in'
     default: 'Backlog'
     required: false
+
+# Allows other actions to use the output of the composite action
+outputs:
+  issue_url:
+    description: 'The URL of the issue that was created'
+    value: ${{ steps.create_issue.outputs.html_url }}
+
 runs:
   using: 'composite'
   steps:


### PR DESCRIPTION
Attempting to access an output from the composite errors as we do not forward the output. 

```
uses: dequelabs/axe-api-team-public/.github/actions/create-project-issue-v1@main
id: create_issue
# ....

# Errors as we do not forward the output from the composite action
uses: another-action
	value: ${{ steps.create_issue_outputs_html_url }}

```

