### PR TITLE
fix(update-axe-core): add version output

### DIFF
--- a/.github/actions/update-axe-core-v1/README.md
+++ b/.github/actions/update-axe-core-v1/README.md
@@ -7,6 +7,7 @@ A GitHub action for updating axe-core to the latest stable version.
 | Name          | Description                                                                                                            |
 | --------------| ---------------------------------------------------------------------------------------------------------------------- |
 | `commit-type` | `feat` if axe-core updated to a major or minor version, `fix` if it updated to a patch version, or `null` if no update occurred |
+| `version`     | The version that axe-core was updated to |
 
 ## Example usage
 

--- a/.github/actions/update-axe-core-v1/action.yml
+++ b/.github/actions/update-axe-core-v1/action.yml
@@ -3,6 +3,9 @@ description: 'A GitHub action for updating axe-core to the latest stable version
 outputs:
   commit-type:
     description: '`feat` if axe-core updated to a major or minor version, `fix` if it updated to a patch version, or `null` if no update occurred'
+  version:
+    description: 'The version that axe-core was updated to'
+
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/.github/actions/update-axe-core-v1/src/run.test.ts
+++ b/.github/actions/update-axe-core-v1/src/run.test.ts
@@ -323,6 +323,17 @@ describe('run', () => {
 
       assert.isTrue(setOutput.calledWith('commit-type', 'fix'))
     })
+
+    it('sets version as axe-core version', async () => {
+      const core = { info, setOutput }
+      await run(
+        core as unknown as Core,
+        getPackageManagerStub,
+        path.join(cwd, 'packages', 'patch-behind')
+      )
+
+      assert.isTrue(setOutput.calledWith('version', '4.8.1'))
+    })
   })
 
   describe('matches axe-core pinning strategy', () => {

--- a/.github/actions/update-axe-core-v1/src/run.ts
+++ b/.github/actions/update-axe-core-v1/src/run.ts
@@ -127,6 +127,8 @@ export default async function run(
     else {
       core.setOutput('commit-type', 'fix')
     }
+
+    core.setOutput('version', latestAxeCoreVersion)
   } catch (error) {
     core.setFailed((error as Error).message)
   }


### PR DESCRIPTION
Didn't realize that the version number was needed in the pr title when creating a pr release.