### PR TITLE
feat: add create-update-axe-core-pull-request-v1

### DIFF
--- a/.github/actions/create-update-axe-core-pull-request-v1/README.md
+++ b/.github/actions/create-update-axe-core-pull-request-v1/README.md
@@ -7,6 +7,7 @@ A GitHub Action to update axe-core and create a pull request.
 | Name                  | Required | Description                                                                                | Default |
 | --------------------- | -------- | ------------------------------------------------------------------------------------------ | ------- |
 | `token`               | Yes      | `GITHUB_TOKEN` (permissions `contents: write` and `pull-requests: write`) or a repo scoped Personal Access Token (PAT).                   | NA      |
+| `base`                | No       | The branch the pull request will be merged into                                            | `develop`      |
 
 ## Example usage
 
@@ -25,5 +26,5 @@ jobs:
     steps:
       - uses: dequelabs/axe-api-team-public/.github/actions/create-update-axe-core-pull-request-v1@main
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/.github/actions/create-update-axe-core-pull-request-v1/README.md
+++ b/.github/actions/create-update-axe-core-pull-request-v1/README.md
@@ -23,7 +23,7 @@ jobs:
   create-project-issue:
     runs-on: ubuntu-latest
     steps:
-      - uses: dequelabs/axe-api-team-public/.github/actions/create-update-axe-pull-core-request-v1@main
+      - uses: dequelabs/axe-api-team-public/.github/actions/create-update-axe-core-pull-request-v1@main
         with:
           token: ${{ secrets.PAT }}
 ```

--- a/.github/actions/create-update-axe-core-pull-request-v1/README.md
+++ b/.github/actions/create-update-axe-core-pull-request-v1/README.md
@@ -1,0 +1,29 @@
+# create-update-axe-pull-core-request-v1
+
+A GitHub Action to update axe-core and create a pull request.
+
+## Inputs
+
+| Name                  | Required | Description                                                                                | Default |
+| --------------------- | -------- | ------------------------------------------------------------------------------------------ | ------- |
+| `token`               | Yes      | `GITHUB_TOKEN` (permissions `contents: write` and `pull-requests: write`) or a repo scoped Personal Access Token (PAT).                   | NA      |
+
+## Example usage
+
+```yaml
+name: Update axe-core
+
+on:
+  schedule:
+    # Run every night at midnight
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  create-project-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dequelabs/axe-api-team-public/.github/actions/create-update-axe-pull-core-request-v1@main
+        with:
+          token: ${{ secrets.PAT }}
+```

--- a/.github/actions/create-update-axe-core-pull-request-v1/action.yml
+++ b/.github/actions/create-update-axe-core-pull-request-v1/action.yml
@@ -1,0 +1,31 @@
+name: create-update-axe-pull-core-request
+description: 'A GitHub Action to update axe-core and create a pull request'
+
+inputs:
+  token:
+    description: '`GITHUB_TOKEN` (permissions `contents: write` and `pull-requests: write`) or a repo scoped Personal Access Token (PAT).'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+    - id: update-axe-core
+      uses: dequelabs/axe-api-team-public/.github/actions/update-axe-core-v1@main
+    - name: Open PR
+      uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # tag=v5
+      with:
+        token: ${{ inputs.token }}
+        commit-message: '${{ steps.update-axe-core.outputs.commit-type }}: Update axe-core to v${{ steps.update-axe-core.outputs.version }}'
+        branch: auto-update-axe-core
+        base: develop
+        title: '${{ steps.update-axe-core.outputs.commit-type }}: Update axe-core to v${{ steps.update-axe-core.outputs.version }}'
+        body: |
+          This pull request updates the version of [`axe-core`](https://npmjs.org/axe-core) to v${{ steps.update-axe-core.outputs.version }}.
+
+          This PR was opened by a robot :robot: :tada:.

--- a/.github/actions/create-update-axe-core-pull-request-v1/action.yml
+++ b/.github/actions/create-update-axe-core-pull-request-v1/action.yml
@@ -5,6 +5,9 @@ inputs:
   token:
     description: '`GITHUB_TOKEN` (permissions `contents: write` and `pull-requests: write`) or a repo scoped Personal Access Token (PAT).'
     required: true
+  base:
+    description: 'The branch the pull request will be merged into'
+    default: 'develop'
 
 runs:
   using: 'composite'
@@ -24,7 +27,7 @@ runs:
         token: ${{ inputs.token }}
         commit-message: '${{ steps.update-axe-core.outputs.commit-type }}: Update axe-core to v${{ steps.update-axe-core.outputs.version }}'
         branch: auto-update-axe-core
-        base: develop
+        base: ${{ inputs.base }}
         title: '${{ steps.update-axe-core.outputs.commit-type }}: Update axe-core to v${{ steps.update-axe-core.outputs.version }}'
         body: |
           This pull request updates the version of [`axe-core`](https://npmjs.org/axe-core) to v${{ steps.update-axe-core.outputs.version }}.

--- a/.github/actions/create-update-axe-core-pull-request-v1/action.yml
+++ b/.github/actions/create-update-axe-core-pull-request-v1/action.yml
@@ -19,7 +19,7 @@ runs:
         node-version: 18
         cache: 'npm'
     - id: update-axe-core
-      uses: dequelabs/axe-api-team-public/.github/actions/create-update-axe-core-pull-request-v1@create-update-axe-core-pull-request
+      uses: dequelabs/axe-api-team-public/.github/actions/update-axe-core-v1@create-update-axe-core-pull-request
     - name: Open PR
       if: ${{ steps.update-axe-core.outputs.commit-type != 'null' }}
       uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # tag=v5

--- a/.github/actions/create-update-axe-core-pull-request-v1/action.yml
+++ b/.github/actions/create-update-axe-core-pull-request-v1/action.yml
@@ -18,6 +18,7 @@ runs:
     - id: update-axe-core
       uses: dequelabs/axe-api-team-public/.github/actions/update-axe-core-v1@main
     - name: Open PR
+      if: ${{ steps.update-axe-core.outputs.commit-type !== null }}
       uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # tag=v5
       with:
         token: ${{ inputs.token }}

--- a/.github/actions/create-update-axe-core-pull-request-v1/action.yml
+++ b/.github/actions/create-update-axe-core-pull-request-v1/action.yml
@@ -19,7 +19,7 @@ runs:
         node-version: 18
         cache: 'npm'
     - id: update-axe-core
-      uses: dequelabs/axe-api-team-public/.github/actions/update-axe-core-v1@create-update-axe-core-pull-request
+      uses: dequelabs/axe-api-team-public/.github/actions/update-axe-core-v1@main
     - name: Open PR
       if: ${{ steps.update-axe-core.outputs.commit-type != null }}
       uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # tag=v5

--- a/.github/actions/create-update-axe-core-pull-request-v1/action.yml
+++ b/.github/actions/create-update-axe-core-pull-request-v1/action.yml
@@ -19,7 +19,7 @@ runs:
         node-version: 18
         cache: 'npm'
     - id: update-axe-core
-      uses: dequelabs/axe-api-team-public/.github/actions/update-axe-core-v1@main
+      uses: dequelabs/axe-api-team-public/.github/actions/create-update-axe-core-pull-request-v1@create-update-axe-core-pull-request
     - name: Open PR
       if: ${{ steps.update-axe-core.outputs.commit-type != 'null' }}
       uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # tag=v5

--- a/.github/actions/create-update-axe-core-pull-request-v1/action.yml
+++ b/.github/actions/create-update-axe-core-pull-request-v1/action.yml
@@ -18,7 +18,7 @@ runs:
     - id: update-axe-core
       uses: dequelabs/axe-api-team-public/.github/actions/update-axe-core-v1@main
     - name: Open PR
-      if: ${{ steps.update-axe-core.outputs.commit-type !== null }}
+      if: ${{ steps.update-axe-core.outputs.commit-type != 'null' }}
       uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # tag=v5
       with:
         token: ${{ inputs.token }}

--- a/.github/actions/create-update-axe-core-pull-request-v1/action.yml
+++ b/.github/actions/create-update-axe-core-pull-request-v1/action.yml
@@ -21,7 +21,7 @@ runs:
     - id: update-axe-core
       uses: dequelabs/axe-api-team-public/.github/actions/update-axe-core-v1@create-update-axe-core-pull-request
     - name: Open PR
-      if: ${{ steps.update-axe-core.outputs.commit-type != 'null' }}
+      if: ${{ steps.update-axe-core.outputs.commit-type != null }}
       uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # tag=v5
       with:
         token: ${{ inputs.token }}

--- a/.github/actions/create-update-axe-core-pull-request-v1/action.yml
+++ b/.github/actions/create-update-axe-core-pull-request-v1/action.yml
@@ -12,9 +12,9 @@ runs:
     - name: Checkout repository
       uses: actions/checkout@v4
     - uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          cache: 'npm'
+      with:
+        node-version: 18
+        cache: 'npm'
     - id: update-axe-core
       uses: dequelabs/axe-api-team-public/.github/actions/update-axe-core-v1@main
     - name: Open PR

--- a/.github/actions/update-axe-core-v1/dist/index.js
+++ b/.github/actions/update-axe-core-v1/dist/index.js
@@ -4392,6 +4392,9 @@ async function run(core, getPackageManager, cwd) {
                 installedAxeCoreVersion = axeCoreVersion.replace(/^[=^~]/, '');
             }
             core.info(`installedAxeCoreVersion after "${installedAxeCoreVersion}"`);
+            core.info(`latestAxeCoreVersion "${latestAxeCoreVersion}"`);
+            core.info(`typeof latestAxeCoreVersion "${typeof latestAxeCoreVersion}"`);
+            core.info(`typeof installedAxeCoreVersion "${typeof installedAxeCoreVersion}"`);
             core.info(`installedAxeCoreVersion === latestAxeCoreVersion ${installedAxeCoreVersion === latestAxeCoreVersion}`);
             if (installedAxeCoreVersion === latestAxeCoreVersion) {
                 core.info('axe-core version is currently at latest, no update required');

--- a/.github/actions/update-axe-core-v1/dist/index.js
+++ b/.github/actions/update-axe-core-v1/dist/index.js
@@ -4344,10 +4344,11 @@ const exec_1 = __nccwpck_require__(1518);
 const path_1 = __importDefault(__nccwpck_require__(1017));
 async function run(core, getPackageManager, cwd) {
     try {
-        const { stdout: latestAxeCoreVersion, stderr: npmInfoError, exitCode: npmExitCode } = await (0, exec_1.getExecOutput)('npm', ['info', 'axe-core', 'version']);
+        const { stdout: npmInfoOut, stderr: npmInfoError, exitCode: npmExitCode } = await (0, exec_1.getExecOutput)('npm', ['info', 'axe-core', 'version']);
         if (npmExitCode) {
             throw new Error(`Error getting latest axe-core version:\n${npmInfoError}`);
         }
+        const latestAxeCoreVersion = npmInfoOut.trim();
         core.info(`latest axe-core version ${latestAxeCoreVersion}`);
         const rootPackageManager = await getPackageManager('./');
         core.info(`root package manager detected as ${rootPackageManager}`);

--- a/.github/actions/update-axe-core-v1/dist/index.js
+++ b/.github/actions/update-axe-core-v1/dist/index.js
@@ -4388,21 +4388,14 @@ async function run(core, getPackageManager, cwd) {
                 pinStrategy = '=';
             }
             core.info(`current axe-core version ${axeCoreVersion}`);
-            core.info(`installedAxeCoreVersion before "${installedAxeCoreVersion}"`);
             if (!installedAxeCoreVersion) {
                 installedAxeCoreVersion = axeCoreVersion.replace(/^[=^~]/, '');
             }
-            core.info(`installedAxeCoreVersion after "${installedAxeCoreVersion}"`);
-            core.info(`latestAxeCoreVersion "${latestAxeCoreVersion}"`);
-            core.info(`typeof latestAxeCoreVersion "${typeof latestAxeCoreVersion}"`);
-            core.info(`typeof installedAxeCoreVersion "${typeof installedAxeCoreVersion}"`);
-            core.info(`installedAxeCoreVersion === latestAxeCoreVersion ${installedAxeCoreVersion === latestAxeCoreVersion}`);
             if (installedAxeCoreVersion === latestAxeCoreVersion) {
                 core.info('axe-core version is currently at latest, no update required');
                 core.setOutput('commit-type', null);
                 return;
             }
-            core.info(`installing axe-core`);
             const { stderr: installError, exitCode: installExitCode } = await (0, exec_1.getExecOutput)(packageManager, [
                 packageManager === 'npm' ? 'i' : 'add',
                 dependencyType,

--- a/.github/actions/update-axe-core-v1/dist/index.js
+++ b/.github/actions/update-axe-core-v1/dist/index.js
@@ -4387,14 +4387,18 @@ async function run(core, getPackageManager, cwd) {
                 pinStrategy = '=';
             }
             core.info(`current axe-core version ${axeCoreVersion}`);
+            core.info(`installedAxeCoreVersion before "${installedAxeCoreVersion}"`);
             if (!installedAxeCoreVersion) {
                 installedAxeCoreVersion = axeCoreVersion.replace(/^[=^~]/, '');
             }
+            core.info(`installedAxeCoreVersion after "${installedAxeCoreVersion}"`);
+            core.info(`installedAxeCoreVersion === latestAxeCoreVersion ${installedAxeCoreVersion === latestAxeCoreVersion}`);
             if (installedAxeCoreVersion === latestAxeCoreVersion) {
                 core.info('axe-core version is currently at latest, no update required');
                 core.setOutput('commit-type', null);
                 return;
             }
+            core.info(`installing axe-core`);
             const { stderr: installError, exitCode: installExitCode } = await (0, exec_1.getExecOutput)(packageManager, [
                 packageManager === 'npm' ? 'i' : 'add',
                 dependencyType,
@@ -4402,7 +4406,7 @@ async function run(core, getPackageManager, cwd) {
             ], {
                 cwd: dirPath
             });
-            if (installError) {
+            if (installExitCode) {
                 throw new Error(`Error installing axe-core:\n${installError}`);
             }
         }

--- a/.github/actions/update-axe-core-v1/src/run.test.ts
+++ b/.github/actions/update-axe-core-v1/src/run.test.ts
@@ -32,7 +32,7 @@ describe('run', () => {
     })
     getExecOutputStub.onFirstCall().returns({
       exitCode: 0,
-      stdout: '4.8.1'
+      stdout: '   4.8.1\n'
     })
     getPackageManagerStub = sinon.stub()
   })
@@ -45,7 +45,7 @@ describe('run', () => {
     await fs.rm(cwd, { recursive: true })
   })
 
-  it('gets latest axe-core version', async () => {
+  it('gets latest axe-core version and trims', async () => {
     const core = { info, setOutput }
     await run(core as unknown as Core, getPackageManagerStub)
 

--- a/.github/actions/update-axe-core-v1/src/run.ts
+++ b/.github/actions/update-axe-core-v1/src/run.ts
@@ -83,7 +83,6 @@ export default async function run(
       }
 
       core.info(`current axe-core version ${axeCoreVersion}`)
-      core.info(`installedAxeCoreVersion before "${installedAxeCoreVersion}"`)
 
       // we expect that all axe-core versions will be the same
       // for every package
@@ -91,22 +90,11 @@ export default async function run(
         installedAxeCoreVersion = axeCoreVersion.replace(/^[=^~]/,'')
       }
 
-      core.info(`installedAxeCoreVersion after "${installedAxeCoreVersion}"`)
-      core.info(`latestAxeCoreVersion "${latestAxeCoreVersion}"`)
-
-      core.info(`typeof latestAxeCoreVersion "${typeof
-        latestAxeCoreVersion}"`)
-      core.info(`typeof installedAxeCoreVersion "${typeof installedAxeCoreVersion}"`)
-
-      core.info(`installedAxeCoreVersion === latestAxeCoreVersion ${installedAxeCoreVersion === latestAxeCoreVersion}`)
-
       if (installedAxeCoreVersion === latestAxeCoreVersion) {
         core.info('axe-core version is currently at latest, no update required')
         core.setOutput('commit-type', null)
         return
       }
-
-      core.info(`installing axe-core`)
 
       const {
         stderr: installError,

--- a/.github/actions/update-axe-core-v1/src/run.ts
+++ b/.github/actions/update-axe-core-v1/src/run.ts
@@ -11,7 +11,7 @@ export default async function run(
 ) {
   try {
     const {
-      stdout: latestAxeCoreVersion,
+      stdout: npmInfoOut,
       stderr: npmInfoError,
       exitCode: npmExitCode
     } = await getExecOutput('npm', ['info', 'axe-core', 'version'])
@@ -19,6 +19,8 @@ export default async function run(
       throw new Error(`Error getting latest axe-core version:\n${npmInfoError}`)
     }
 
+    // `npm info`` adds newline character to end of the output
+    const latestAxeCoreVersion = npmInfoOut.trim()
     core.info(`latest axe-core version ${latestAxeCoreVersion}`)
 
     // npm and yarn workspaces will have a lock file at the root

--- a/.github/actions/update-axe-core-v1/src/run.ts
+++ b/.github/actions/update-axe-core-v1/src/run.ts
@@ -90,6 +90,12 @@ export default async function run(
       }
 
       core.info(`installedAxeCoreVersion after "${installedAxeCoreVersion}"`)
+      core.info(`latestAxeCoreVersion "${latestAxeCoreVersion}"`)
+
+      core.info(`typeof latestAxeCoreVersion "${typeof
+        latestAxeCoreVersion}"`)
+      core.info(`typeof installedAxeCoreVersion "${typeof installedAxeCoreVersion}"`)
+
       core.info(`installedAxeCoreVersion === latestAxeCoreVersion ${installedAxeCoreVersion === latestAxeCoreVersion}`)
 
       if (installedAxeCoreVersion === latestAxeCoreVersion) {

--- a/.github/actions/update-axe-core-v1/src/run.ts
+++ b/.github/actions/update-axe-core-v1/src/run.ts
@@ -81,6 +81,7 @@ export default async function run(
       }
 
       core.info(`current axe-core version ${axeCoreVersion}`)
+      core.info(`installedAxeCoreVersion before "${installedAxeCoreVersion}"`)
 
       // we expect that all axe-core versions will be the same
       // for every package
@@ -88,11 +89,16 @@ export default async function run(
         installedAxeCoreVersion = axeCoreVersion.replace(/^[=^~]/,'')
       }
 
+      core.info(`installedAxeCoreVersion after "${installedAxeCoreVersion}"`)
+      core.info(`installedAxeCoreVersion === latestAxeCoreVersion ${installedAxeCoreVersion === latestAxeCoreVersion}`)
+
       if (installedAxeCoreVersion === latestAxeCoreVersion) {
         core.info('axe-core version is currently at latest, no update required')
         core.setOutput('commit-type', null)
         return
       }
+
+      core.info(`installing axe-core`)
 
       const {
         stderr: installError,


### PR DESCRIPTION
Creates a single action to update axe-core and open a pull request. We investigated using dependabot to do this for us as it maintains the pinning strategy, but dependabot does not allow multiple entries for different ecosystems. So we can't define both a monthly cadence for everything excluding axe-core and a daily cadence for axe-core.

Requires: https://github.com/dequelabs/axe-api-team-public/pull/65

Closes: https://github.com/dequelabs/update-axe-core/issues/9
Closes: https://github.com/dequelabs/axe-api-team-public/issues/30

Successful action run: https://github.com/dequelabs/straker-test-repo/actions/runs/6549902423/job/17787837546
Pr to update axe-core: https://github.com/dequelabs/straker-test-repo/pull/20
Action cancel after up-to-date: https://github.com/dequelabs/straker-test-repo/actions/runs/6549828140/job/17787609809