### PR TITLE
chore: fix name and improve READMEs for *update-axe-core* actions

### DIFF
--- a/.github/actions/create-update-axe-core-pull-request-v1/README.md
+++ b/.github/actions/create-update-axe-core-pull-request-v1/README.md
@@ -1,6 +1,15 @@
-# create-update-axe-pull-core-request-v1
+# create-update-axe-core-pull-request-v1
 
-A GitHub Action to update axe-core and create a pull request.
+A GitHub action to create a PR that updates axe-core to the latest stable version. It noops if no update is available.
+
+- It updates `package.json`, `yarn.lock`, and `package-lock.json`.
+- It is compatible with both workspaces and non-workspaces monorepos.
+- It handles dependencies and devDependencies.
+- It maintains whatever pinning strategy was already in place (`~`, `^`, or `=`).
+
+Workflows should generally use this instead of using [update-axe-core](../update-axe-core-v1/README.md) directly.
+
+This action can be replaced with dependabot config once [dependabot-core#1778](https://github.com/dependabot/dependabot-core/issues/1778) is resolved.
 
 ## Inputs
 

--- a/.github/actions/create-update-axe-core-pull-request-v1/action.yml
+++ b/.github/actions/create-update-axe-core-pull-request-v1/action.yml
@@ -1,4 +1,4 @@
-name: create-update-axe-pull-core-request
+name: create-update-axe-core-pull-request
 description: 'A GitHub Action to update axe-core and create a pull request'
 
 inputs:

--- a/.github/actions/update-axe-core-v1/README.md
+++ b/.github/actions/update-axe-core-v1/README.md
@@ -2,6 +2,14 @@
 
 A GitHub action for updating axe-core to the latest stable version.
 
+- It updates `package.json`, `yarn.lock`, and `package-lock.json`.
+- It is compatible with both workspaces and non-workspaces monorepos.
+- It handles dependencies and devDependencies.
+- It maintains whatever pinning strategy was already in place (`~`, `^`, or `=`).
+- It does *not* commit changes or create a PR.
+
+Workflows should generally use [create-update-axe-core-pull-request](../create-update-axe-core-pull-request-v1/README.md) instead of using this action directly.
+
 ## Outputs
 
 | Name          | Description                                                                                                            |


### PR DESCRIPTION
Noticed a typo in the name of `create-update-axe-pull-core-request-v1`, cleaned up readme while I was updating anyway to make it more obvious to a reader exactly what "update" means

No QA required.