### PR TITLE
chore: add mocha eslint plugin and block `only` tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,11 +6,17 @@ module.exports = {
     'eslint:recommended',
     'plugin:@typescript-eslint/eslint-recommended',
     'plugin:@typescript-eslint/recommended',
+    'plugin:mocha/recommended'
   ],
   rules: {
     '@typescript-eslint/camelcase': 'off',
     '@typescript-eslint/interface-name-prefix': 'off',
-    '@typescript-eslint/no-use-before-define': 'off'
+    '@typescript-eslint/no-use-before-define': 'off',
+    'mocha/no-mocha-arrows': 'off',
+    'mocha/no-setup-in-describe': 'off',
+    // We export test functions / utilities to be used in other tests within the same repo
+    'mocha/no-exports': 'off',
+    'mocha/no-exclusive-tests': 'error'
   },
   env: {
     node: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "conventional-commits-parser": "^5.0.0",
         "dedent": "^1.5.1",
         "eslint": "^8.54.0",
+        "eslint-plugin-mocha": "^10.2.0",
         "glob": "^10.3.10",
         "husky": "^8.0.2",
         "lint-staged": "^15.1.0",
@@ -2230,6 +2231,49 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-mocha": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.2.0.tgz",
+      "integrity": "sha512-ZhdxzSZnd1P9LqDPF0DBcFLpRIGdh1zkF2JHnQklKQOvrQtT73kdP5K9V2mzvbLR+cCAO9OI48NXK/Ax9/ciCQ==",
+      "dev": true,
+      "dependencies": {
+        "eslint-utils": "^3.0.0",
+        "rambda": "^7.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "engines": {
+        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=5"
+      }
+    },
+    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/eslint-visitor-keys": {
@@ -4504,6 +4548,12 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/rambda": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/rambda/-/rambda-7.5.0.tgz",
+      "integrity": "sha512-y/M9weqWAH4iopRd7EHDEQQvpFPHj1AA3oHozE9tfITHUtTR7Z9PSlIRRG2l1GuW7sefC1cXFfIcF+cgnShdBA==",
+      "dev": true
     },
     "node_modules/randombytes": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "prepare": "husky install",
     "build": "npm --workspaces run build",
-    "test": "npm --workspaces run test"
+    "test": "npm --workspaces run test",
+    "lint": "npm --workspaces run lint"
   },
   "devDependencies": {
     "@actions/core": "^1.10.1",
@@ -37,6 +38,7 @@
     "conventional-commits-parser": "^5.0.0",
     "dedent": "^1.5.1",
     "eslint": "^8.54.0",
+    "eslint-plugin-mocha": "^10.2.0",
     "glob": "^10.3.10",
     "husky": "^8.0.2",
     "lint-staged": "^15.1.0",


### PR DESCRIPTION
Added mocha' eslint plugin to block `.only` tests from being pushed (see https://github.com/dequelabs/axe-api-team-public/actions/runs/7133577665/job/19426575903?pr=101)


No QA Required