### PR TITLE
fix(.github/actions/get-release-issue-v1): ensure output is set to null when no release issue is found

### DIFF
--- a/.github/actions/get-release-issue-v1/dist/index.js
+++ b/.github/actions/get-release-issue-v1/dist/index.js
@@ -30976,6 +30976,7 @@ async function run(core, github) {
         const issues = JSON.parse(issueList);
         if (!issues.length) {
             core.warning(`No issues found for ${owner}/${repo} v${version}. It may have already been closed...`);
+            core.setOutput('issue-url', null);
             return;
         }
         if (issues.length > 1) {

--- a/.github/actions/get-release-issue-v1/src/run.test.ts
+++ b/.github/actions/get-release-issue-v1/src/run.test.ts
@@ -318,6 +318,41 @@ describe('run', () => {
           'No issues found for owner/repo v1.0.0. It may have already been closed...'
         )
       })
+
+      it('sets the issue-url output to null', async () => {
+        inputStub.withArgs('version', { required: true }).returns('1.0.0')
+        inputStub.withArgs('owner').returns('owner')
+        inputStub.withArgs('repo').returns('repo')
+
+        execStub.returns({
+          stdout: '[]',
+          stderr: '',
+          exitCode: 0
+        })
+
+        const core = {
+          getInput: inputStub,
+          info: infoSpy,
+          setFailed: setFailedSpy,
+          warning: warningSpy,
+          setOutput: setOutputSpy
+        } as unknown as Core
+
+        const github = {
+          context: {
+            repo: {
+              owner: 'owner',
+              repo: 'repo'
+            }
+          }
+        } as GitHub
+
+        await run(core, github)
+
+        assert.isTrue(setOutputSpy.calledOnce)
+        assert.equal(setOutputSpy.args[0][0], 'issue-url')
+        assert.equal(setOutputSpy.args[0][1], null)
+      })
     })
 
     describe('when more than one issue is found', () => {

--- a/.github/actions/get-release-issue-v1/src/run.ts
+++ b/.github/actions/get-release-issue-v1/src/run.ts
@@ -28,6 +28,9 @@ export default async function run(core: Core, github: GitHub) {
       core.warning(
         `No issues found for ${owner}/${repo} v${version}. It may have already been closed...`
       )
+
+      // Set the `issue-url` output to `null` so that it can be checked in subsequent steps in other workflows
+      core.setOutput('issue-url', null)
       return
     }
 


### PR DESCRIPTION
Without setting the output when there are no issues found causes the workflow to proceed to the next step even though the step has a `!= ''` check, we have to set the output. 

ref: https://github.com/dequelabs/zidious-testing/actions/runs/7453971019/job/20280393389#step:2:109


No QA Required