### PR TITLE
fix(create-update-axe-core-pull-request-v1): remove caching to allow use in monorepos

### DIFF
--- a/.github/actions/create-update-axe-core-pull-request-v1/action.yml
+++ b/.github/actions/create-update-axe-core-pull-request-v1/action.yml
@@ -17,7 +17,6 @@ runs:
     - uses: actions/setup-node@v3
       with:
         node-version: 18
-        cache: 'npm'
     - id: update-axe-core
       uses: dequelabs/axe-api-team-public/.github/actions/update-axe-core-v1@main
     - name: Open PR


### PR DESCRIPTION

Setup node caching to npm requires a lock file to exist on the root which not all repos have.  
[axe-core-nuget](https://github.com/dequelabs/axe-core-nuget)
[axe-core-gems](https://github.com/dequelabs/axe-core-gems)

Ref: https://stackoverflow.com/a/68717538

no qa required