### PR TITLE
chore: only run build in changed dirs

### DIFF
--- a/.github/workflows/update-generated-files.yml
+++ b/.github/workflows/update-generated-files.yml
@@ -52,7 +52,7 @@ jobs:
           git checkout -b $BRANCH_NAME
           git commit -m "chore: sync generated files"
           git push origin $BRANCH_NAME
-          gh pr create --base main --head $BRANCH_NAME --title "chore: sync generated files" --body ""
+          gh pr create --base main --head $BRANCH_NAME --title "chore: sync generated files" --body "This PR was opened by a robot :robot: :tada:."
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,30 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npm run build -ws
+# only run the npm build script for each workspace directory that has changed files
+function run_build {
+  # convert multiline string into array
+  # @see https://stackoverflow.com/questions/24628076/convert-multiline-string-to-array
+  local IFS=$'\n'
+  local lines=($1)
+  local i
+
+  # get only the unique values from an array
+  # `lines[$i]%%/*` gets the substring up to the first '/'. so `semantic-pr-footer-v1/src/run.ts` becomes `semantic-pr-footer-v1`
+  # @see https://www.baeldung.com/linux/bash-unique-values-arrays
+  unique_dirs=($(for (( i=0; i<${#lines[@]}; i++ )) ; do echo "${lines[$i]%%/*}"; done | sort -u))
+
+  for dir in "${unique_dirs[@]}"; do
+     npm run build -w "$dir"
+  done
+}
+
+cd ./.github/actions
+files=$(git diff HEAD~1 --name-only --relative)
+if [ "$files" != "" ]; then
+  run_build "$files"
+fi
+
+cd ../../
 git add .
 npx lint-staged


### PR DESCRIPTION
This change allows the lint-staged command to only run the build in the workspace where files changed. That way we don't run the build for every workspace and the prs are scoped to only where the changes happened.

Also making sure the pr for generating the files has body text.