### PR TITLE
chore: fix husky precommit hook not running code in bash

### DIFF
--- a/.github/workflows/update-generated-files.yml
+++ b/.github/workflows/update-generated-files.yml
@@ -2,6 +2,8 @@ name: Update generated files
 
 on:
   push:
+    branches:
+      - main
 
 env:
   BRANCH_NAME: sync-generated-files

--- a/.github/workflows/update-generated-files.yml
+++ b/.github/workflows/update-generated-files.yml
@@ -2,8 +2,6 @@ name: Update generated files
 
 on:
   push:
-    branches:
-      - main
 
 env:
   BRANCH_NAME: sync-generated-files

--- a/.husky/build-changed-files.sh
+++ b/.husky/build-changed-files.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# only run the npm build script for each workspace directory that has changed files
+function run_build {
+  # convert multiline string into array
+  # @see https://stackoverflow.com/questions/24628076/convert-multiline-string-to-array
+  local IFS=$'\n'
+  local lines=($1)
+  local i
+
+  # get only the unique values from an array
+  # `lines[$i]%%/*` gets the substring up to the first '/'. so `semantic-pr-footer-v1/src/run.ts` becomes `semantic-pr-footer-v1`
+  # @see https://www.baeldung.com/linux/bash-unique-values-arrays
+  unique_dirs=($(for (( i=0; i<${#lines[@]}; i++ )) ; do echo "${lines[$i]%%/*}"; done | sort -u))
+
+  for dir in "${unique_dirs[@]}"; do
+     npm run build -w "$dir"
+  done
+}
+
+cd "$(dirname -- "$0")/../.github/actions"
+files=$(git diff HEAD~1 --name-only --relative)
+if [ "$files" != "" ]; then
+  run_build "$files"
+fi
+
+git add .

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,30 +1,8 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-# only run the npm build script for each workspace directory that has changed files
-function run_build {
-  # convert multiline string into array
-  # @see https://stackoverflow.com/questions/24628076/convert-multiline-string-to-array
-  local IFS=$'\n'
-  local lines=($1)
-  local i
-
-  # get only the unique values from an array
-  # `lines[$i]%%/*` gets the substring up to the first '/'. so `semantic-pr-footer-v1/src/run.ts` becomes `semantic-pr-footer-v1`
-  # @see https://www.baeldung.com/linux/bash-unique-values-arrays
-  unique_dirs=($(for (( i=0; i<${#lines[@]}; i++ )) ; do echo "${lines[$i]%%/*}"; done | sort -u))
-
-  for dir in "${unique_dirs[@]}"; do
-     npm run build -w "$dir"
-  done
-}
-
-cd ./.github/actions
-files=$(git diff HEAD~1 --name-only --relative)
-if [ "$files" != "" ]; then
-  run_build "$files"
-fi
-
-cd ../../
-git add .
+# this file requires bash to run in github actions (github
+# actions use dash as default `sh` command)
+# @see https://github.com/typicode/husky/issues/1326
+bash "$(dirname -- "$0")/build-changed-files.sh"
 npx lint-staged


### PR DESCRIPTION
Turns out that Github actions don't use `bash` as the shell script when running a file with `sh`. Husky runs all hook scripts using the `sh` command which would break in Github actions. Changed to separate the file out in order to get bash commands (needed for reading the list of diff files into an array and parsing unique values out) and invoking the file specifically with `bash`.

no qa required