### PR TITLE
fix: add dependency type after dependency

### DIFF
--- a/.github/actions/update-axe-core-v1/dist/index.js
+++ b/.github/actions/update-axe-core-v1/dist/index.js
@@ -27249,8 +27249,8 @@ async function run(core, getPackageManager, cwd) {
             }
             const { stderr: installError, exitCode: installExitCode } = await (0, exec_1.getExecOutput)(packageManager, [
                 packageManager === 'npm' ? 'i' : 'add',
-                dependencyType,
-                `axe-core@${pinStrategy}${latestAxeCoreVersion}`
+                `axe-core@${pinStrategy}${latestAxeCoreVersion}`,
+                dependencyType
             ], {
                 cwd: dirPath
             });

--- a/.github/actions/update-axe-core-v1/src/run.test.ts
+++ b/.github/actions/update-axe-core-v1/src/run.test.ts
@@ -190,7 +190,7 @@ describe('run', () => {
       await run(core as unknown as Core, getPackageManagerStub, dirPath)
 
       assert.isTrue(
-        getExecOutputStub.calledWith('npm', ['i', '', sinon.match.any], {
+        getExecOutputStub.calledWith('npm', ['i', sinon.match.any, ''], {
           cwd: dirPath
         })
       )
@@ -203,7 +203,7 @@ describe('run', () => {
       await run(core as unknown as Core, getPackageManagerStub, dirPath)
 
       assert.isTrue(
-        getExecOutputStub.calledWith('yarn', ['add', '', sinon.match.any], {
+        getExecOutputStub.calledWith('yarn', ['add', sinon.match.any, ''], {
           cwd: dirPath
         })
       )
@@ -217,7 +217,7 @@ describe('run', () => {
       await run(core as unknown as Core, getPackageManagerStub, dirPath)
 
       assert.isTrue(
-        getExecOutputStub.calledWith('yarn', ['add', '', sinon.match.any], {
+        getExecOutputStub.calledWith('yarn', ['add', sinon.match.any, ''], {
           cwd: dirPath
         })
       )
@@ -349,7 +349,7 @@ describe('run', () => {
         await run(core as unknown as Core, getPackageManagerStub, dirPath)
 
         assert.isTrue(
-          getExecOutputStub.calledWith('npm', ['i', '', `axe-core@${pin}`], {
+          getExecOutputStub.calledWith('npm', ['i', `axe-core@${pin}`, ''], {
             cwd: dirPath
           })
         )

--- a/.github/actions/update-axe-core-v1/src/run.ts
+++ b/.github/actions/update-axe-core-v1/src/run.ts
@@ -102,8 +102,8 @@ export default async function run(
           packageManager,
           [
             packageManager === 'npm' ? 'i' : 'add',
-            dependencyType,
-            `axe-core@${pinStrategy}${latestAxeCoreVersion}`
+            `axe-core@${pinStrategy}${latestAxeCoreVersion}`,
+            dependencyType
           ],
           {
             cwd: dirPath


### PR DESCRIPTION
Using yarn in github action for some reason fails when there is a space prior to the dependency you want to update. 

no qa required