### PR TITLE
chore(.github/actions): add input to optionally checkout create-release-candidate-v1

### DIFF
--- a/.github/actions/create-release-candidate-v1/README.md
+++ b/.github/actions/create-release-candidate-v1/README.md
@@ -12,6 +12,7 @@ A GitHub Action to create a release candidate.
 | `release-script-path` | Yes      | The path to the [release script](#release-script-requirements) that creates the changelogs and bumps the version of the package(s)                                                                                              | NA      |
 | `version-locked`      | No       | Whether or not the version bump should treat major/minor as "locked". Repos which version-lock to axe-core should default this to `true`, overriding it to `false` only for releases that update `axe-core`.                    | `false` |
 | `docs-repo`           | No       | The name of the repo where the release notes live                                                                                                                                                                               | `null`  |
+| `should-checkout`     | No       | Whether or not the action should checkout the repository.                                                                                                                                                                       | `true`  |
 
 ## Example usage
 

--- a/.github/actions/create-release-candidate-v1/action.yml
+++ b/.github/actions/create-release-candidate-v1/action.yml
@@ -22,11 +22,15 @@ inputs:
     description: 'The name of the repo where the release notes live'
     default: 'null'
     required: false
+  should-checkout:
+    description: 'Whether or not the action should checkout the repository'
+    default: 'true'
 
 runs:
   using: 'composite'
   steps:
     - name: Checkout repository
+      if: ${{ inputs.should-checkout == 'true' }}
       uses: actions/checkout@v4
       with:
         # Fetch all history


### PR DESCRIPTION
Add optional input `should-checkout` that will add default to `true` that will checkout the repo otherwise when passed `should-checkout: 'false'` the action caller will need to checkout the repo. 

No QA Required