### PR TITLE
feat(.github/action): change the label-and-move-released-issues and move-released-issues-and-create-sync-pr actions to change a column name

### DIFF
--- a/.github/actions/label-and-move-released-issues-v1/README.md
+++ b/.github/actions/label-and-move-released-issues-v1/README.md
@@ -1,15 +1,16 @@
 # label-and-move-released-issues-v1
 
-This action labels and moves issues that have been released to the `released` column of a project board.
+This action labels and moves issues that have been released.
 
 ## Inputs
 
-| Name             | Required | Description                                                          | Default |
-| ---------------- | -------- | -------------------------------------------------------------------- | ------- |
-| `commit-list`    | Yes      | The list of commits generated from the "Generate commit list" action | NA      |
-| `version`        | Yes      | The version number of the release                                    | NA      |
-| `token`          | Yes      | The GitHub token with the required permissions (see below)           | NA      |
-| `project-number` | No       | The project number of the project board                              | `66`    |
+| Name             | Required | Description                                                          | Default  |
+| ---------------- | -------- | -------------------------------------------------------------------- | -------- |
+| `commit-list`    | Yes      | The list of commits generated from the "Generate commit list" action | NA       |
+| `version`        | Yes      | The version number of the release                                    | NA       |
+| `token`          | Yes      | The GitHub token with the required permissions (see below)           | NA       |
+| `project-number` | No       | The project number of the project board                              | 66       |
+| `column-name`    | No       | Name of column to move to                                            | released |
 
 ## Example
 
@@ -33,9 +34,11 @@ jobs:
           head: 'develop'
       - uses: dequelabs/axe-api-team-public/.github/actions/label-and-move-released-issues-v1@main
         with:
+          token: ${{ secrets.PAT }}
           commit-list: '${{ steps.commits.outputs.commit-list }}'
           version: 1.1.0
-          token: ${{ secrets.PAT }}
+          project-number: '66'
+          column-name: 'released'
         env:
           # Requires for GH CLI
           GH_TOKEN: ${{ secrets.PAT }}

--- a/.github/actions/label-and-move-released-issues-v1/action.yml
+++ b/.github/actions/label-and-move-released-issues-v1/action.yml
@@ -1,5 +1,5 @@
 name: 'Label and move released issues'
-description: 'Label and move issues that have been released to the "Released" column'
+description: 'Label and move issues that have been released'
 inputs:
   commit-list:
     description: 'The list of commits generated from the "Generate Commit List" action'
@@ -12,7 +12,12 @@ inputs:
     required: true
   project-number:
     description: 'The project number of the project board'
+    required: false
     default: '66'
+  column-name:
+    description: 'Name of column to move to'
+    required: false
+    default: 'released'
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/.github/actions/label-and-move-released-issues-v1/dist/index.js
+++ b/.github/actions/label-and-move-released-issues-v1/dist/index.js
@@ -31146,13 +31146,13 @@ async function run(core, github) {
         const version = core.getInput('version', { required: true });
         const token = core.getInput('token', { required: true });
         const projectNumber = parseInt(core.getInput('project-number'));
+        const releaseColumn = core.getInput('column-name');
         if (isNaN(projectNumber)) {
             core.setFailed('`project-number` must be a number');
             return;
         }
         const octokit = github.getOctokit(token);
         const { repo, owner } = github.context.repo;
-        const releaseColumn = 'released';
         const [{ id: projectBoardID }, { fields }] = await Promise.all([
             (0, getProjectBoardID_1.default)({ projectNumber, owner }),
             (0, getProjectBoardFieldList_1.default)({ projectNumber, owner })

--- a/.github/actions/label-and-move-released-issues-v1/src/run.test.ts
+++ b/.github/actions/label-and-move-released-issues-v1/src/run.test.ts
@@ -117,6 +117,7 @@ describe('run', () => {
     version?: string
     token?: string
     projectNumber?: string
+    releaseColumn?: string
   }
 
   const generateInputs = (inputs?: Partial<GenerateInputsArgs>) => {
@@ -132,12 +133,16 @@ describe('run', () => {
     const projectNumber = getInput
       .withArgs('project-number')
       .returns(inputs?.projectNumber ?? '66')
+    const releaseColumn = getInput
+      .withArgs('column-name')
+      .returns(inputs?.releaseColumn ?? 'released')
 
     return {
       commitList,
       version,
       token,
-      projectNumber
+      projectNumber,
+      releaseColumn
     }
   }
 

--- a/.github/actions/label-and-move-released-issues-v1/src/run.ts
+++ b/.github/actions/label-and-move-released-issues-v1/src/run.ts
@@ -13,6 +13,7 @@ export default async function run(core: Core, github: GitHub): Promise<void> {
     const version = core.getInput('version', { required: true })
     const token = core.getInput('token', { required: true })
     const projectNumber = parseInt(core.getInput('project-number'))
+    const releaseColumn = core.getInput('column-name')
 
     if (isNaN(projectNumber)) {
       core.setFailed('`project-number` must be a number')
@@ -22,7 +23,6 @@ export default async function run(core: Core, github: GitHub): Promise<void> {
     const octokit = github.getOctokit(token)
     const { repo, owner } = github.context.repo
 
-    const releaseColumn = 'released'
     const [{ id: projectBoardID }, { fields }] = await Promise.all([
       getProjectBoardID({ projectNumber, owner }),
       getProjectBoardFieldList({ projectNumber, owner })

--- a/.github/actions/move-released-issues-and-create-sync-pr-v1/README.md
+++ b/.github/actions/move-released-issues-and-create-sync-pr-v1/README.md
@@ -8,6 +8,7 @@ A GitHub Action to label all related issues with the package version and create 
 | ------------------- | -------- | -------------------------------------------- | ------------ |
 | `token`             | Yes      | A GitHub token with the required permissions | NA           |
 | `project-number`    | No       | A project number of the project board        | 66           |
+| `column-name`       | No       | Name of column to move to                    | released     |
 | `head`              | No       | A head branch to sync from                   | main         |
 | `base`              | No       | A target branch for the created pull request | develop      |
 | `pr-team-reviewers` | No       | Reviewers to tag on the created pull request | axe-api-team |
@@ -30,6 +31,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           project-number: '66'
+          column-name: 'released'
           head: main
           base: develop
           pr-team-reviewers: axe-api-team

--- a/.github/actions/move-released-issues-and-create-sync-pr-v1/action.yml
+++ b/.github/actions/move-released-issues-and-create-sync-pr-v1/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: 'A project number of the project board'
     required: false
     default: '66'
+  column-name:
+    description: 'Name of column to move to'
+    required: false
+    default: 'released'
   head:
     description: 'A head branch to sync from'
     required: false
@@ -46,6 +50,7 @@ runs:
         version: ${{ steps.get-previous-tag.outputs.tag-version }}
         token: ${{ inputs.token }}
         project-number: ${{ inputs.project-number }}
+        column-name: ${{ inputs.column-name }}
     - uses: dequelabs/action-sync-branches@master
       with:
         github-token: ${{ inputs.token }}


### PR DESCRIPTION
Added the input `column-name` in the `label-and-move-released-issues` and `move-released-issues-and-create-sync-pr` actions.

Closes: [#505](https://github.com/dequelabs/axe-api-team/issues/505)