### PR TITLE
fix(update-axe-core): avoid installing "undefined" in npm-based repos

### DIFF
--- a/.github/actions/update-axe-core-v1/dist/index.js
+++ b/.github/actions/update-axe-core-v1/dist/index.js
@@ -27166,14 +27166,17 @@ const getPackageManager_1 = __importDefault(__nccwpck_require__(7167));
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-function default_1({ packageManager, pinStrategy, latestAxeCoreVersion, dependencyType }) {
+function default_1({ packageManager, pinStrategy, latestAxeCoreVersion, dependencyGroup }) {
     const newAxeVersion = `axe-core@${pinStrategy}${latestAxeCoreVersion}`;
-    if (packageManager !== 'yarn') {
-        return ['i', newAxeVersion, dependencyType];
+    if (packageManager === 'npm') {
+        const dependencyTypeArgs = dependencyGroup === 'dependencies' ? [] : ['-D'];
+        return ['i', ...dependencyTypeArgs, newAxeVersion];
     }
-    return dependencyType === '-D'
-        ? ['add', newAxeVersion, '-D']
-        : ['add', newAxeVersion];
+    else if (packageManager === 'yarn') {
+        const dependencyTypeArgs = dependencyGroup === 'dependencies' ? [] : ['-D'];
+        return ['add', ...dependencyTypeArgs, newAxeVersion];
+    }
+    throw new Error(`unsupported packageManager: ${packageManager}`);
 }
 exports["default"] = default_1;
 
@@ -27250,11 +27253,10 @@ async function run(core, getPackageManager, cwd) {
                 continue;
             }
             core.info(`package specific package manager detected as ${packageManager}`);
-            const dependency = pkg.dependencies?.['axe-core']
+            const dependencyGroup = pkg.dependencies?.['axe-core']
                 ? 'dependencies'
                 : 'devDependencies';
-            const dependencyType = dependency === 'dependencies' ? '' : '-D';
-            const axeCoreVersion = pkg[dependency]['axe-core'];
+            const axeCoreVersion = pkg[dependencyGroup]['axe-core'];
             let pinStrategy = axeCoreVersion.charAt(0);
             if (pinStrategy.match(/\d/)) {
                 pinStrategy = '=';
@@ -27272,7 +27274,7 @@ async function run(core, getPackageManager, cwd) {
                 packageManager,
                 pinStrategy,
                 latestAxeCoreVersion,
-                dependencyType
+                dependencyGroup
             }), {
                 cwd: dirPath
             });

--- a/.github/actions/update-axe-core-v1/dist/installScript.d.ts
+++ b/.github/actions/update-axe-core-v1/dist/installScript.d.ts
@@ -1,8 +1,8 @@
 interface InstallScriptParams {
-    packageManager: string;
+    packageManager: 'npm' | 'yarn';
     pinStrategy: string;
     latestAxeCoreVersion: string;
-    dependencyType: string;
+    dependencyGroup: 'dependencies' | 'devDependencies';
 }
-export default function ({ packageManager, pinStrategy, latestAxeCoreVersion, dependencyType }: InstallScriptParams): string[];
+export default function ({ packageManager, pinStrategy, latestAxeCoreVersion, dependencyGroup }: InstallScriptParams): string[];
 export {};

--- a/.github/actions/update-axe-core-v1/src/installScript.test.ts
+++ b/.github/actions/update-axe-core-v1/src/installScript.test.ts
@@ -66,4 +66,24 @@ describe('installScript', () => {
       assert.deepEqual(actual, expected)
     })
   })
+
+  describe('when the package manager is unsupported', () => {
+    it('throws', () => {
+      const packageManager = 'unknown'
+      const pinStrategy = '='
+      const latestAxeCoreVersion = '4.2.1'
+      const dependencyGroup = 'dependencies'
+      assert.throws(
+        () =>
+          installScript({
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            packageManager: packageManager as any,
+            pinStrategy,
+            latestAxeCoreVersion,
+            dependencyGroup
+          }),
+        `unsupported packageManager: ${packageManager}`
+      )
+    })
+  })
 })

--- a/.github/actions/update-axe-core-v1/src/installScript.test.ts
+++ b/.github/actions/update-axe-core-v1/src/installScript.test.ts
@@ -4,49 +4,64 @@ import installScript from './installScript'
 
 describe('installScript', () => {
   describe('when the package manager is npm', () => {
-    it('should return the correct install script', () => {
+    it('should return the correct install script for runtime deps', () => {
       const packageManager = 'npm'
       const pinStrategy = '='
       const latestAxeCoreVersion = '4.2.1'
-      const dependencyType = ''
-      const expected = ['i', 'axe-core@=4.2.1', '']
+      const dependencyGroup = 'dependencies'
+      const expected = ['i', 'axe-core@=4.2.1']
       const actual = installScript({
         packageManager,
         pinStrategy,
         latestAxeCoreVersion,
-        dependencyType
+        dependencyGroup
+      })
+      assert.deepEqual(actual, expected)
+    })
+
+    it('should return the correct install script for dev deps', () => {
+      const packageManager = 'npm'
+      const pinStrategy = '='
+      const latestAxeCoreVersion = '4.2.1'
+      const dependencyGroup = 'devDependencies'
+      const expected = ['i', '-D', 'axe-core@=4.2.1']
+      const actual = installScript({
+        packageManager,
+        pinStrategy,
+        latestAxeCoreVersion,
+        dependencyGroup
       })
       assert.deepEqual(actual, expected)
     })
   })
 
   describe('when the package manager is yarn', () => {
-    it('should return the correct install script', () => {
+    it('should return the correct install script for runtime deps', () => {
       const packageManager = 'yarn'
       const pinStrategy = '='
       const latestAxeCoreVersion = '4.2.1'
-      const dependencyType = ''
+      const dependencyGroup = 'dependencies'
       const expected = ['add', 'axe-core@=4.2.1']
       const actual = installScript({
         packageManager,
         pinStrategy,
         latestAxeCoreVersion,
-        dependencyType
+        dependencyGroup
       })
       assert.deepEqual(actual, expected)
     })
 
-    it('should return the correct install script when the dependency type is dev', () => {
+    it('should return the correct install script for dev deps', () => {
       const packageManager = 'yarn'
       const pinStrategy = '='
       const latestAxeCoreVersion = '4.2.1'
-      const dependencyType = '-D'
-      const expected = ['add', 'axe-core@=4.2.1', '-D']
+      const dependencyGroup = 'devDependencies'
+      const expected = ['add', '-D', 'axe-core@=4.2.1']
       const actual = installScript({
         packageManager,
         pinStrategy,
         latestAxeCoreVersion,
-        dependencyType
+        dependencyGroup
       })
       assert.deepEqual(actual, expected)
     })

--- a/.github/actions/update-axe-core-v1/src/installScript.ts
+++ b/.github/actions/update-axe-core-v1/src/installScript.ts
@@ -1,26 +1,25 @@
 interface InstallScriptParams {
-  packageManager: string
+  packageManager: 'npm' | 'yarn'
   pinStrategy: string
   latestAxeCoreVersion: string
-  dependencyType: string
+  dependencyGroup: 'dependencies' | 'devDependencies'
 }
 
 export default function ({
   packageManager,
   pinStrategy,
   latestAxeCoreVersion,
-  dependencyType
+  dependencyGroup
 }: InstallScriptParams) {
-const newAxeVersion = `axe-core@${pinStrategy}${latestAxeCoreVersion}`
+  const newAxeVersion = `axe-core@${pinStrategy}${latestAxeCoreVersion}`
 
-  if (packageManager !== 'yarn') {
-    return ['i', newAxeVersion, dependencyType]
+  if (packageManager === 'npm') {
+    const dependencyTypeArgs = dependencyGroup === 'dependencies' ? [] : ['-D']
+    return ['i', ...dependencyTypeArgs, newAxeVersion]
+  } else if (packageManager === 'yarn') {
+    const dependencyTypeArgs = dependencyGroup === 'dependencies' ? [] : ['-D']
+    return ['add', ...dependencyTypeArgs, newAxeVersion]
   }
 
-  // When running using a child process it considers 
-  // an empty string a value and returns an error
-  // @see https://github.com/yarnpkg/yarn/issues/5228
-  return dependencyType === '-D'
-    ? ['add', newAxeVersion, '-D']
-    : ['add', newAxeVersion]
+  throw new Error(`unsupported packageManager: ${packageManager}`)
 }

--- a/.github/actions/update-axe-core-v1/src/run.test.ts
+++ b/.github/actions/update-axe-core-v1/src/run.test.ts
@@ -190,7 +190,7 @@ describe('run', () => {
       await run(core as unknown as Core, getPackageManagerStub, dirPath)
 
       assert.isTrue(
-        getExecOutputStub.calledWith('npm', ['i', sinon.match.any, ''], {
+        getExecOutputStub.calledWith('npm', ['i', sinon.match.any], {
           cwd: dirPath
         })
       )
@@ -349,7 +349,7 @@ describe('run', () => {
         await run(core as unknown as Core, getPackageManagerStub, dirPath)
 
         assert.isTrue(
-          getExecOutputStub.calledWith('npm', ['i', `axe-core@${pin}`, ''], {
+          getExecOutputStub.calledWith('npm', ['i', `axe-core@${pin}`], {
             cwd: dirPath
           })
         )

--- a/.github/actions/update-axe-core-v1/src/run.ts
+++ b/.github/actions/update-axe-core-v1/src/run.ts
@@ -71,12 +71,11 @@ export default async function run(
         `package specific package manager detected as ${packageManager}`
       )
 
-      const dependency = pkg.dependencies?.['axe-core']
+      const dependencyGroup = pkg.dependencies?.['axe-core']
         ? 'dependencies'
         : 'devDependencies'
 
-      const dependencyType = dependency === 'dependencies' ? '' : '-D'
-      const axeCoreVersion = pkg[dependency]['axe-core']
+      const axeCoreVersion = pkg[dependencyGroup]['axe-core']
       let pinStrategy = axeCoreVersion.charAt(0)
 
       // axe-core version was exactly pinned but not using "="
@@ -105,7 +104,7 @@ export default async function run(
             packageManager,
             pinStrategy,
             latestAxeCoreVersion,
-            dependencyType
+            dependencyGroup
           }),
           {
             cwd: dirPath


### PR DESCRIPTION
Verified locally that running `npx ts-node ~/repos/axe-api-team-public/.github/actions/update-axe-core-v1/src/index.ts` from within my `axe-core-npm` clone before this PR adds the same `undefined` refs that we saw in https://github.com/dequelabs/axe-core-npm/pull/1054 and that after this PR it doesn't.

Closes: #112