### PR TITLE
ci(.github/action): add a docs issue url into the create-release-candidate action

### DIFF
--- a/.github/actions/create-release-candidate-v1/action.yml
+++ b/.github/actions/create-release-candidate-v1/action.yml
@@ -193,7 +193,7 @@ runs:
           ### Links
           - [X] Release candidate PR: ${{ steps.create_pull_request.outputs.pull-request-url }}
           - [ ] Release PR:
-          - [ ] Docs Issue:
+          - [X] Docs Issue: ${{ steps.create_release_notes_issue.outputs.issue_url }}
           - [ ] Change Management Form:
           - [ ] Notes:
           ```


### PR DESCRIPTION
Added a docs issue URL into the release issue template

Closes: #165 