### PR TITLE
fix(create-release): ensure action does not fail when migrations dir is provided but no new files are found

### DIFF
--- a/.github/actions/create-release-v1/action.yml
+++ b/.github/actions/create-release-v1/action.yml
@@ -71,6 +71,7 @@ runs:
         echo "Repo url: $repo_url"
 
         # Only get new files added to release branch that are within the provided migrations directory and end in .sql
+        # If the directory is provided but there are no new migration files, return an empty string
         new_migration_files=$(git diff --name-only --diff-filter=A  origin/${{ inputs.base }}...origin/release -- "${{ inputs.migrations-dir }}" | grep -E '\.sql$' || echo "") 
 
         if [ -n "$new_migration_files" ]; then

--- a/.github/actions/create-release-v1/action.yml
+++ b/.github/actions/create-release-v1/action.yml
@@ -65,13 +65,14 @@ runs:
       if: ${{ inputs.migrations-dir != '' }}
       shell: bash
       run: |
+        // TODO: HERE
+        set -x
         repo_url="https://github.com/$GITHUB_REPOSITORY"
 
         echo "Checking for new migration files in ${{ inputs.migrations-dir }}"
         echo "Repo url: $repo_url"
 
         # Only get new files added to release branch that are within the provided migrations directory and end in .sql
-
         new_migration_files=$(git diff --name-only --diff-filter=A  origin/${{ inputs.base }}...origin/release -- "${{ inputs.migrations-dir }}" | grep -E '\.sql$')
 
         if [ -n "$new_migration_files" ]; then

--- a/.github/actions/create-release-v1/action.yml
+++ b/.github/actions/create-release-v1/action.yml
@@ -65,15 +65,13 @@ runs:
       if: ${{ inputs.migrations-dir != '' }}
       shell: bash
       run: |
-        // TODO: HERE
-        set -x
         repo_url="https://github.com/$GITHUB_REPOSITORY"
 
         echo "Checking for new migration files in ${{ inputs.migrations-dir }}"
         echo "Repo url: $repo_url"
 
         # Only get new files added to release branch that are within the provided migrations directory and end in .sql
-        new_migration_files=$(git diff --name-only --diff-filter=A  origin/${{ inputs.base }}...origin/release -- "${{ inputs.migrations-dir }}" | grep -E '\.sql$')
+        new_migration_files=$(git diff --name-only --diff-filter=A  origin/${{ inputs.base }}...origin/release -- "${{ inputs.migrations-dir }}" | grep -E '\.sql$') || ""
 
         if [ -n "$new_migration_files" ]; then
           echo "## New migration files found:" >> /tmp/release-notes.txt

--- a/.github/actions/create-release-v1/action.yml
+++ b/.github/actions/create-release-v1/action.yml
@@ -71,7 +71,7 @@ runs:
         echo "Repo url: $repo_url"
 
         # Only get new files added to release branch that are within the provided migrations directory and end in .sql
-        new_migration_files=$(git diff --name-only --diff-filter=A  origin/${{ inputs.base }}...origin/release -- "${{ inputs.migrations-dir }}" | grep -E '\.sql$') || ""
+        new_migration_files=$(git diff --name-only --diff-filter=A  origin/${{ inputs.base }}...origin/release -- "${{ inputs.migrations-dir }}" | grep -E '\.sql$' || echo "") 
 
         if [ -n "$new_migration_files" ]; then
           echo "## New migration files found:" >> /tmp/release-notes.txt


### PR DESCRIPTION
When the `migrations-dir` input is given and there are no new migration files found we would error: 
https://github.com/dequelabs/zidious-testing/actions/runs/9162107575/job/25188409931#step:2:147

This was not intended behaviour - instead we gracefully handle finding no `.sql` files to an empty string. This results in the create-release action to complete: 

PR created: https://github.com/dequelabs/zidious-testing/pull/135


When there is a new migration file found: 

Workflow: https://github.com/dequelabs/zidious-testing/actions/runs/9162710013
PR created: https://github.com/dequelabs/zidious-testing/pull/138

Closes: https://github.com/dequelabs/axe-api-team-public/issues/162