### PR TITLE
ci(.github/action): add release candidate version input in the abort-release-candidate action

### DIFF
--- a/.github/actions/abort-release-candidate-v1/README.md
+++ b/.github/actions/abort-release-candidate-v1/README.md
@@ -4,12 +4,12 @@ A GitHub Action to abort a release candidate.
 
 ## Inputs
 
-| Name        | Required | Description                                                                              | Default |
-| ----------- | -------- | ---------------------------------------------------------------------------------------- | ------- |
-| `token`     | Yes      | A GitHub token used for octokit and GH CLI with the [required permissions](#permissions) | NA      |
-| `base`      | Yes      | The base branch the release candidate was going to be merged into                        | NA      |
-| `docs-repo` | No       | The docs repo where the release notes issue is located                                   | NA      |
-| `version`   | No       | The release candidate version number that will be aborted (e.g 1.0.0)                    | NA      |
+| Name        | Required | Description                                                                              | Default                             |
+| ----------- | -------- | ---------------------------------------------------------------------------------------- | ----------------------------------- |
+| `token`     | Yes      | A GitHub token used for octokit and GH CLI with the [required permissions](#permissions) | NA                                  |
+| `base`      | Yes      | The base branch the release candidate was going to be merged into                        | NA                                  |
+| `docs-repo` | No       | The docs repo where the release notes issue is located                                   | NA                                  |
+| `version`   | No       | The release candidate version number that will be aborted (e.g 1.0.0)                    | from `lerna.json` or `package.json` |
 
 ## Permissions
 

--- a/.github/actions/abort-release-candidate-v1/README.md
+++ b/.github/actions/abort-release-candidate-v1/README.md
@@ -4,12 +4,12 @@ A GitHub Action to abort a release candidate.
 
 ## Inputs
 
-| Name        | Required | Description                                                                              | Default                             |
-| ----------- | -------- | ---------------------------------------------------------------------------------------- | ----------------------------------- |
-| `token`     | Yes      | A GitHub token used for octokit and GH CLI with the [required permissions](#permissions) | NA                                  |
-| `base`      | Yes      | The base branch the release candidate was going to be merged into                        | NA                                  |
-| `docs-repo` | No       | The docs repo where the release notes issue is located                                   | NA                                  |
-| `version`   | No       | The release candidate version number that will be aborted (e.g 1.0.0)                    | from `lerna.json` or `package.json` |
+| Name        | Required                                          | Description                                                                              | Default                                                           |
+| ----------- | ------------------------------------------------- | ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `token`     | Yes                                               | A GitHub token used for octokit and GH CLI with the [required permissions](#permissions) | NA                                                                |
+| `base`      | Yes                                               | The base branch the release candidate was going to be merged into                        | NA                                                                |
+| `docs-repo` | No                                                | The docs repo where the release notes issue is located                                   | NA                                                                |
+| `version`   | only if the RC PR has not yet merged to `release` | The release candidate version number that will be aborted (e.g 1.0.0)                    | inferred from the release branch's `lerna.json` or `package.json` |
 
 ## Permissions
 

--- a/.github/actions/abort-release-candidate-v1/README.md
+++ b/.github/actions/abort-release-candidate-v1/README.md
@@ -9,6 +9,7 @@ A GitHub Action to abort a release candidate.
 | `token`     | Yes      | A GitHub token used for octokit and GH CLI with the [required permissions](#permissions) | NA      |
 | `base`      | Yes      | The base branch the release candidate was going to be merged into                        | NA      |
 | `docs-repo` | No       | The docs repo where the release notes issue is located                                   | NA      |
+| `version`   | No       | The release candidate version number that will be aborted (e.g 1.0.0)                    | NA      |
 
 ## Permissions
 
@@ -36,4 +37,5 @@ jobs:
           token: ${{ secrets.PAT }}
           base: 'main'
           docs-repo: 'my-docs-repo'
+          version: '1.0.0'
 ```

--- a/.github/actions/abort-release-candidate-v1/action.yml
+++ b/.github/actions/abort-release-candidate-v1/action.yml
@@ -42,10 +42,11 @@ runs:
           if [ -f "lerna.json" ]; then
             VERSION=$(cat lerna.json | jq -r '.version')
           else
-           VERSION=$(cat package.json | jq -r '.version')
+            VERSION=$(cat package.json | jq -r '.version')
           fi
         fi
 
+        echo "The release candidate version: $VERSION"
         echo "release_candidate_version=$VERSION" >> $GITHUB_OUTPUT
 
     - name: Get release candidate issue url

--- a/.github/actions/abort-release-candidate-v1/action.yml
+++ b/.github/actions/abort-release-candidate-v1/action.yml
@@ -12,6 +12,9 @@ inputs:
     description: 'The docs repository where the issue for the release candidate is located'
     default: ''
     required: false
+  version:
+    description: 'The release candidate version number that will be aborted (e.g 1.0.0)'
+    required: false
 
 runs:
   using: 'composite'
@@ -28,14 +31,20 @@ runs:
       shell: bash
       id: get-release-candidate-version
       run: |
-        # Get the version number from the prepare_release shell script and set it as an output
-        # Monorepos have a lerna.json file that contains the updated version number
-        # Non-monorepos, or non-npm repos, have a package.json file that contains the updated version number
-        if [ -f "lerna.json" ]; then
-          echo "release_candidate_version=$(cat lerna.json | jq -r '.version')" >> $GITHUB_OUTPUT
-        else
-          echo "release_candidate_version=$(cat package.json | jq -r '.version')" >> $GITHUB_OUTPUT
+        VERSION="${{ inputs.version }}"
+        
+        if [ -z "$VERSION" ]; then
+          # Get the version number from the prepare_release shell script and set it as an output
+          # Monorepos have a lerna.json file that contains the updated version number
+          # Non-monorepos, or non-npm repos, have a package.json file that contains the updated version number
+          if [ -f "lerna.json" ]; then
+            VERSION=$(cat lerna.json | jq -r '.version')
+          else
+           VERSION=$(cat package.json | jq -r '.version')
+          fi
         fi
+
+        echo "release_candidate_version=$VERSION" >> $GITHUB_OUTPUT
 
     - name: Get release candidate issue url
       uses: dequelabs/axe-api-team-public/.github/actions/get-release-issue-v1@main


### PR DESCRIPTION
Added an optional release candidate version input to abort the exact RC. If this input is not provided the GHA will take the version from `lerna.json` (if it exists) or from the `package.json`.

Closes: [#513](https://github.com/dequelabs/axe-api-team/issues/513)