### PR TITLE
fix(abort-release-candidate): pass PAT to checkout

### DIFF
--- a/.github/actions/abort-release-candidate-v1/action.yml
+++ b/.github/actions/abort-release-candidate-v1/action.yml
@@ -23,6 +23,8 @@ runs:
         fetch-depth: 0
         # Checkout the release branch so we can get the release candidate version and reset it to the base branch later
         ref: 'release'
+        # PAT has required permissions force pushing when the `release` branch is checked out
+        token: ${{ inputs.token }}
 
     - name: Get release candidate version
       shell: bash


### PR DESCRIPTION
This allows the checkout action to checkout the `release` branch using the PAT token provided which has the required permission scopes for resetting.

No QA Required