### PR TITLE
ci: pin conventional-commits-parser >=6 due to ESM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,8 @@ updates:
       # Prevent updates to ESM-only versions
       - dependency-name: 'chai'
         versions: ['>=5']
+      - dependency-name: 'conventional-commits-parser'
+        versions: ['>=6']
     groups:
       # Any updates not caught by the group config will get individual PRs
       npm-low-risk:


### PR DESCRIPTION
As of v6 of conventional-commits-parser it is now [ESM only](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-commits-parser/CHANGELOG.md#600-2024-04-26)

Ref: https://github.com/dequelabs/axe-api-team-public/pull/177


No QA Required