### PR TITLE
ci(.github/action): change the label-and-move-released-issues action to work with the issue owner and the issue repo

### DIFF
--- a/.github/actions/label-and-move-released-issues-v1/dist/label-and-move-released-issues-v1/src/getReferencedClosedIssues.d.ts
+++ b/.github/actions/label-and-move-released-issues-v1/dist/label-and-move-released-issues-v1/src/getReferencedClosedIssues.d.ts
@@ -11,6 +11,12 @@ export interface GetReferencedClosedIssuesResult {
             closingIssuesReferences: {
                 nodes: {
                     number: number;
+                    repository: {
+                        owner: {
+                            login: string;
+                        };
+                        name: string;
+                    };
                 }[];
             };
         };

--- a/.github/actions/label-and-move-released-issues-v1/src/getReferencedClosedIssues.test.ts
+++ b/.github/actions/label-and-move-released-issues-v1/src/getReferencedClosedIssues.test.ts
@@ -12,7 +12,11 @@ const MOCK_REFERENCED_CLOSED_ISSUES: GetReferencedClosedIssuesResult = {
       closingIssuesReferences: {
         nodes: [
           {
-            number: 27
+            number: 27,
+            repository: {
+              owner: { login: 'issue-owner' },
+              name: 'issue-repo-name'
+            }
           }
         ]
       }

--- a/.github/actions/label-and-move-released-issues-v1/src/getReferencedClosedIssues.ts
+++ b/.github/actions/label-and-move-released-issues-v1/src/getReferencedClosedIssues.ts
@@ -34,6 +34,10 @@ export interface GetReferencedClosedIssuesResult {
       closingIssuesReferences: {
         nodes: {
           number: number
+          repository: {
+            owner: { login: string }
+            name: string
+          }
         }[]
       }
     }
@@ -57,6 +61,14 @@ export default async function getReferencedClosedIssues({
             nodes {
               # The issue number of the issue that was closed
               number
+              repository {
+                # The owner where an issue was created
+                owner {
+                  login
+                }
+                # The repo name where an issue was created
+                name
+              }
             }
           }
          }

--- a/.github/actions/label-and-move-released-issues-v1/src/run.test.ts
+++ b/.github/actions/label-and-move-released-issues-v1/src/run.test.ts
@@ -66,7 +66,11 @@ const MOCK_REFERENCED_CLOSED_ISSUES = {
       closingIssuesReferences: {
         nodes: [
           {
-            number: 27
+            number: 27,
+            repository: {
+              owner: { login: 'issue-owner' },
+              name: 'issue-repo-name'
+            }
           }
         ]
       }

--- a/.github/actions/label-and-move-released-issues-v1/src/run.ts
+++ b/.github/actions/label-and-move-released-issues-v1/src/run.ts
@@ -167,6 +167,7 @@ export default async function run(core: Core, github: GitHub): Promise<void> {
           core.info(
             `The label "${LABEL}" does not exist for the issue repo ${issueOwner}/${issueRepo}, creating...`
           )
+
           await octokit.rest.issues.createLabel({
             repo: issueRepo,
             owner: issueOwner,

--- a/.github/actions/label-and-move-released-issues-v1/src/run.ts
+++ b/.github/actions/label-and-move-released-issues-v1/src/run.ts
@@ -7,6 +7,12 @@ import getProjectBoardFieldList from '../../add-to-board-v1/src/getProjectBoardF
 import addIssueToBoard from '../../add-to-board-v1/src/addIssueToBoard'
 import moveIssueToColumn from '../../add-to-board-v1/src/moveIssueToColumn'
 
+interface IssueData {
+  number: number
+  owner: string
+  repo: string
+}
+
 export default async function run(core: Core, github: GitHub): Promise<void> {
   try {
     const commitList = core.getInput('commit-list', { required: true })
@@ -29,7 +35,7 @@ export default async function run(core: Core, github: GitHub): Promise<void> {
     ])
 
     // Status is the default field name for the project board columns e.g. Backlog, In progress, Done etc
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+
     const statusField = fields.find(
       field => field.name.toLowerCase() === 'status'
     )!
@@ -70,6 +76,9 @@ export default async function run(core: Core, github: GitHub): Promise<void> {
      * update the issue column in add-to-board action via composite run steps
      */
     const issueURLs: string[] = []
+    let issueOwner: string
+    let issueRepo: string
+    let issueNumber: number
 
     const commits = JSON.parse(commitList) as ParsedCommitList[]
     core.info(`Found ${commits.length} commits`)
@@ -87,32 +96,45 @@ export default async function run(core: Core, github: GitHub): Promise<void> {
         octokit
       })
 
-      const issueIDs =
-        referenceClosedIssues.repository.pullRequest.closingIssuesReferences.nodes.map(
-          n => n.number
+      const issueDataArr: IssueData[] =
+        referenceClosedIssues.repository.pullRequest.closingIssuesReferences.nodes.reduce(
+          (arr: IssueData[], item) => {
+            arr.push({
+              number: item.number,
+              owner: item.repository.owner.login,
+              repo: item.repository.name
+            })
+
+            return arr
+          },
+          []
         )
 
-      if (!issueIDs.length) {
+      if (!issueDataArr.length) {
         core.info('\nNo issues found for commit, moving on...')
         continue
       }
 
-      for (const issueNumber of issueIDs) {
+      for (const issueData of issueDataArr) {
+        issueOwner = issueData.owner
+        issueRepo = issueData.repo
+        issueNumber = issueData.number
+
         core.info(
-          `\nFetching project board info for: ${owner}, ${repo}, issue: ${issueNumber} for project: ${projectNumber}`
+          `\nFetching project board info for: ${owner}/${repo},  PR: ${id}, issue: ${issueNumber} for project: ${projectNumber}`
         )
 
-        const issueStatus = await getIssueProjectInfo({
-          owner,
-          repo,
+        const issueStats = await getIssueProjectInfo({
+          owner: issueOwner,
+          repo: issueRepo,
           issueNumber,
           octokit
         })
 
-        core.info(`Found stats: ${JSON.stringify(issueStatus)}`)
+        core.info(`Found stats: ${JSON.stringify(issueStats)}`)
 
         const projectBoard =
-          issueStatus.repository.issue.projectItems.nodes.find(
+          issueStats.repository.issue.projectItems.nodes.find(
             n => n.project.number === projectNumber
           )
 
@@ -134,23 +156,23 @@ export default async function run(core: Core, github: GitHub): Promise<void> {
         }
 
         const { data: issue } = await octokit.rest.issues.get({
-          repo,
-          owner,
+          repo: issueRepo,
+          owner: issueOwner,
           issue_number: issueNumber
         })
 
         if (issue.state !== 'closed') {
           await octokit.rest.issues.update({
-            repo,
-            owner,
+            repo: issueRepo,
+            owner: issueOwner,
             issue_number: issueNumber,
             state: 'closed'
           })
         }
 
         octokit.rest.issues.addLabels({
-          repo,
-          owner,
+          repo: issueRepo,
+          owner: issueOwner,
           issue_number: issueNumber,
           labels: [LABEL]
         })


### PR DESCRIPTION
Changed the label-and-move-released-issues action to work with the issue owner and the issue repo. Before the changes, we had an error if an issue in a PR was related to another repo (a different repo that a PR is related to). Right now this action will work with the issue's repo name.

Ref: [#518](https://github.com/dequelabs/axe-api-team/issues/518)