### PR TITLE
fix: update default board to point to new bass team

### DIFF
--- a/.github/actions/label-and-move-released-issues-v1/README.md
+++ b/.github/actions/label-and-move-released-issues-v1/README.md
@@ -9,7 +9,7 @@ This action labels and moves issues that have been released.
 | `commit-list`    | Yes      | The list of commits generated from the "Generate commit list" action | NA       |
 | `version`        | Yes      | The version number of the release                                    | NA       |
 | `token`          | Yes      | The GitHub token with the required permissions (see below)           | NA       |
-| `project-number` | No       | The project number of the project board                              | 66       |
+| `project-number` | No       | The project number of the project board                              | 186      |
 | `column-name`    | No       | Name of column to move to                                            | released |
 
 ## Example

--- a/.github/actions/label-and-move-released-issues-v1/action.yml
+++ b/.github/actions/label-and-move-released-issues-v1/action.yml
@@ -13,7 +13,7 @@ inputs:
   project-number:
     description: 'The project number of the project board'
     required: false
-    default: '66'
+    default: '186'
   column-name:
     description: 'Name of column to move to'
     required: false


### PR DESCRIPTION
Blame jenn - 🍐 _forced_ me to update to 186 (bass team board).

No QA Required