### PR TITLE
docs(semantic-pr-footer): Make allowed footers known

### DIFF
--- a/.github/actions/semantic-pr-footer-v1/README.md
+++ b/.github/actions/semantic-pr-footer-v1/README.md
@@ -27,3 +27,22 @@ jobs:
     steps:
       - uses: dequelabs/axe-api-team-public/.github/actions/semantic-pr-footer-v1@main
 ```
+
+## Allowable footers
+
+The footer of a PR will fail unless it [_starts with_ one of the following strings (case insensitive)](https://github.com/dequelabs/axe-api-team-public/blob/main/.github/actions/semantic-pr-footer-v1/src/isValidFooter.ts#L1):
+
+- "close: "
+- "closes: "
+- "closed: "
+- "fix: "
+- "fixes: "
+- "fixed: "
+- "resolve: "
+- "resolves: "
+- "resolved: "
+- "ref: "
+- "refs: "
+- "qa notes: "
+- "no qa required"
+- "no qa needed"


### PR DESCRIPTION
See https://github.com/dequelabs/launchpad/pull/66#issuecomment-2243844743

![pr failing check for unreasonable cause](https://github.com/user-attachments/assets/35c20b95-e6d2-4007-948c-e2c04671066a)

QA notes: I like doggies