### PR TITLE
feat(.github/actions): add optional `setup-node` in update-axe-core action

### DIFF
--- a/.github/actions/create-update-axe-core-pull-request-v1/README.md
+++ b/.github/actions/create-update-axe-core-pull-request-v1/README.md
@@ -17,6 +17,8 @@ This action can be replaced with dependabot config once [dependabot-core#1778](h
 | ------- | -------- | ----------------------------------------------------------------------------------------------------------------------- | --------- |
 | `token` | Yes      | `GITHUB_TOKEN` (permissions `contents: write` and `pull-requests: write`) or a repo scoped Personal Access Token (PAT). | NA        |
 | `base`  | No       | The branch the pull request will be merged into                                                                         | `develop` |
+| `should-checkout`  | No       | Whether or not the action should checkout the repository                                                                           | `true` |
+| `should-setup-node`  | No       | Whether or not the action should setup node on behalf of the consumer                                                                         | `true` |
 
 ## Example usage
 

--- a/.github/actions/create-update-axe-core-pull-request-v1/action.yml
+++ b/.github/actions/create-update-axe-core-pull-request-v1/action.yml
@@ -11,14 +11,19 @@ inputs:
   should-checkout:
     description: 'Whether or not the action should checkout the repository'
     default: 'true'
-
+  should-setup-node:
+    description: 'Whether or not the action should setup node on behalf of the consumer'
+    default: 'true'
+    
 runs:
   using: 'composite'
   steps:
     - name: Checkout repository
       if: ${{ inputs.should-checkout == 'true' }}
       uses: actions/checkout@v4
-    - uses: actions/setup-node@v3
+    - name: Setup Node
+      if: ${{ inputs.should-checkout == 'true' }}
+      uses: actions/setup-node@v4
       with:
         node-version: 18
     - id: update-axe-core

--- a/.github/actions/create-update-axe-core-pull-request-v1/action.yml
+++ b/.github/actions/create-update-axe-core-pull-request-v1/action.yml
@@ -22,7 +22,7 @@ runs:
       if: ${{ inputs.should-checkout == 'true' }}
       uses: actions/checkout@v4
     - name: Setup Node
-      if: ${{ inputs.should-checkout == 'true' }}
+      if: ${{ inputs.should-setup-node == 'true' }}
       uses: actions/setup-node@v4
       with:
         node-version: 18


### PR DESCRIPTION
This patch adds optional input `should-setup-node` which defaults to `true` to maintain existing behavior. Some repos already setup node in a previous step in the action with a particular version there is no need to re-setup node as it could checkout with a previous version of Node and/or waste minutes.

No QA Required