### PR TITLE
chore(.github/action): change `project-number`, `column-name`, Slack channel for the new team-results team

### DIFF
--- a/.github/actions/abort-release-candidate-v1/action.yml
+++ b/.github/actions/abort-release-candidate-v1/action.yml
@@ -65,13 +65,13 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.token }}
 
-    - name: Move release candidate issue to `Release Cancelled` column (Board 103)
+    - name: Move release candidate issue to `No` column (Board 188)
       if: steps.get-release-issue.outputs.issue-url != null
       uses: dequelabs/axe-api-team-public/.github/actions/add-to-board-v1@main
       with:
         issue-urls: ${{ steps.get-release-issue.outputs.issue-url }}
-        column-name: 'Release Cancelled'
-        project-number: '103'
+        column-name: 'No'
+        project-number: '188'
       env:
         GH_TOKEN: ${{ inputs.token }}
 
@@ -94,13 +94,13 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.token }}
 
-    - name: Move release candidate doc issue to `Cancelled` column (Board 171)
+    - name: Move release candidate doc issue to `Cancelled` column (Board 193)
       if: inputs.docs-repo != '' && steps.get-release-issue-from-docs-repo.outputs.issue-url != null
       uses: dequelabs/axe-api-team-public/.github/actions/add-to-board-v1@main
       with:
         issue-urls: ${{ steps.get-release-issue-from-docs-repo.outputs.issue-url }}
         column-name: 'Cancelled'
-        project-number: '171'
+        project-number: '193'
       env:
         GH_TOKEN: ${{ inputs.token }}
 

--- a/.github/actions/add-to-board-v1/README.md
+++ b/.github/actions/add-to-board-v1/README.md
@@ -4,11 +4,11 @@ A GitHub Action to move issues to a specific column on a project board.
 
 ## Inputs
 
-| Name             | Required | Description                                                    | Default   |
-| ---------------- | -------- | -------------------------------------------------------------- | --------- |
-| `issue-urls`     | Yes      | Comma delimited list of issue urls to add to the project board | NA        |
-| `project-number` | No       | The project number to add the issue to                         | `66`      |
-| `column-name`    | No       | The column name to move the issue to                           | `Backlog` |
+| Name             | Required | Description                                                    | Default |
+| ---------------- | -------- | -------------------------------------------------------------- | ------- |
+| `issue-urls`     | Yes      | Comma delimited list of issue urls to add to the project board | NA      |
+| `project-number` | No       | The project number to add the issue to                         | `188`   |
+| `column-name`    | No       | The column name to move the issue to                           | `New`   |
 
 ## Permissions
 

--- a/.github/actions/add-to-board-v1/action.yml
+++ b/.github/actions/add-to-board-v1/action.yml
@@ -6,10 +6,10 @@ inputs:
     required: true
   project-number:
     description: 'The project board number to add the issue to'
-    default: '66'
+    default: '188'
   column-name:
     description: 'Name of column to add to'
-    default: 'Backlog'
+    default: 'New'
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/.github/actions/auto-major-minor-release-v1/action.yml
+++ b/.github/actions/auto-major-minor-release-v1/action.yml
@@ -132,14 +132,17 @@ runs:
     - name: Move to board
       uses: dequelabs/axe-api-team-public/.github/actions/add-to-board-v1@main
       with:
-        token: ${{ inputs.project_token }}
-        issue-id: ${{ steps.issue-id.outputs.id }}
-        # 66 taken from the url: https://github.com/orgs/dequelabs/projects/66
-        project-number: 66
+        issue-urls: ${{ steps.issue-id.outputs.id }}
+        # 188 taken from the url: https://github.com/orgs/dequelabs/projects/188
+        project-number: 188
+        column-name: New
+      env:
+        # Required for the GH CLI
+        GH_TOKEN: ${{ inputs.project_token }}
     - name: Slack Notification
       uses: rtCamp/action-slack-notify@b24d75fe0e728a4bf9fc42ee217caa686d141ee8 # tag=v2
       env:
-        SLACK_CHANNEL: api-team-releases
+        SLACK_CHANNEL: results-team-dev
         SLACK_COLOR: ${{ job.status }} # or a specific color like 'good' or '#ff00ff'
         SLACK_MESSAGE: |
           The develop branch of ${{ github.event.repository.name }} is ready for QA.

--- a/.github/actions/auto-patch-release-v1/action.yml
+++ b/.github/actions/auto-patch-release-v1/action.yml
@@ -162,14 +162,17 @@ runs:
     - name: Move to board
       uses: dequelabs/axe-api-team-public/.github/actions/add-to-board-v1@main
       with:
-        token: ${{ inputs.project_token }}
-        issue-id: ${{ steps.issue-id.outputs.id }}
-        # 66 taken from the url: https://github.com/orgs/dequelabs/projects/66
-        project-number: 66
+        issue-urls: ${{ steps.issue-id.outputs.id }}
+        # 188 taken from the url: https://github.com/orgs/dequelabs/projects/188
+        project-number: 188
+        column-name: New
+      env:
+        # Required for the GH CLI
+        GH_TOKEN: ${{ inputs.project_token }}
     - name: Slack Notification
       uses: rtCamp/action-slack-notify@b24d75fe0e728a4bf9fc42ee217caa686d141ee8 # tag=v2
       env:
-        SLACK_CHANNEL: api-team-releases
+        SLACK_CHANNEL: results-team-dev
         SLACK_COLOR: ${{ job.status }} # or a specific color like 'good' or '#ff00ff'
         SLACK_MESSAGE: |
           The develop branch of ${{ github.event.repository.name }} is ready for QA.

--- a/.github/actions/create-project-issue-v1/README.md
+++ b/.github/actions/create-project-issue-v1/README.md
@@ -10,8 +10,8 @@ A GitHub Action to create a new issue and move the issue to a specific column on
 | `body`           | The body of the issue                                                                                                              | Yes      | NA                          |
 | `labels`         | Comma separated list of labels to add to the issue                                                                                 | No       | NA                          |
 | `assignees`      | Comma separated list of assignees to add to the issue                                                                              | No       | NA                          |
-| `project-number` | The number of the project board to add the issue to                                                                                | No       | `66`                        |
-| `column-name`    | The name of the column within the project board to add the issue to                                                                | No       | `Backlog`                   |
+| `project-number` | The number of the project board to add the issue to                                                                                | No       | `188`                       |
+| `column-name`    | The name of the column within the project board to add the issue to                                                                | No       | `New`                       |
 | `token`          | The GitHub token, used for creating the issue and adding to project board                                                          | No       | `github.token`              |
 | `repo`           | The repository to create the issue in e.g. if the repository is under dequelabs/axe-core-npm, then supply "axe-core-npm"           | No       | `github.context.repo.repo`  |
 | `owner`          | The owner of the repository to create the issue in e.g. if the repository is under dequelabs/axe-core-npm, then supply "dequelabs" | No       | `github.context.repo.owner` |

--- a/.github/actions/create-project-issue-v1/action.yml
+++ b/.github/actions/create-project-issue-v1/action.yml
@@ -28,11 +28,11 @@ inputs:
     required: false
   project_number:
     description: 'The project board number to create the issue in'
-    default: '66'
+    default: '188'
     required: false
   column_name:
     description: 'The column name to create the issue in'
-    default: 'Backlog'
+    default: 'New'
     required: false
 
 # Allows other actions to use the output of the composite action

--- a/.github/actions/create-release-candidate-v1/action.yml
+++ b/.github/actions/create-release-candidate-v1/action.yml
@@ -161,8 +161,8 @@ runs:
         repo: ${{ inputs.docs-repo }}
         labels: ${{ inputs.docs-labels }}
         assignees: 'enlarsen'
-        project_number: '171'
-        column_name: 'To Do'
+        project_number: '193'
+        column_name: 'Todo'
         title: '${{ github.repository }} v${{ steps.get_bumped_version_number.outputs.version }} - Release Notes Needed'
         body: |
           PR: ${{ steps.create_pull_request.outputs.pull-request-url }}
@@ -175,8 +175,8 @@ runs:
       with:
         token: ${{ inputs.token }}
         labels: 'PRIORITY: high,release'
-        project_number: '103'
-        column_name: 'Release Candidate'
+        project_number: '188'
+        column_name: 'New'
         title: '${{ github.repository }} v${{ steps.get_bumped_version_number.outputs.version }}'
         body: |
           # Below is everything related to this release 

--- a/.github/actions/label-and-move-released-issues-v1/README.md
+++ b/.github/actions/label-and-move-released-issues-v1/README.md
@@ -9,7 +9,7 @@ This action labels and moves issues that have been released.
 | `commit-list`    | Yes      | The list of commits generated from the "Generate commit list" action | NA      |
 | `version`        | Yes      | The version number of the release                                    | NA      |
 | `token`          | Yes      | The GitHub token with the required permissions (see below)           | NA      |
-| `project-number` | No       | The project number of the project board                              | 186     |
+| `project-number` | No       | The project number of the project board                              | 188     |
 | `column-name`    | No       | Name of column to move to, if one is provided                        | `''`    |
 
 ## Example

--- a/.github/actions/label-and-move-released-issues-v1/action.yml
+++ b/.github/actions/label-and-move-released-issues-v1/action.yml
@@ -13,7 +13,7 @@ inputs:
   project-number:
     description: 'The project number of the project board'
     required: false
-    default: '186'
+    default: '188'
   column-name:
     description: 'Name of column to move to'
     required: false

--- a/.github/actions/move-released-issues-and-create-sync-pr-v1/README.md
+++ b/.github/actions/move-released-issues-and-create-sync-pr-v1/README.md
@@ -7,11 +7,11 @@ A GitHub Action to label all related issues with the package version and create 
 | Name                | Required | Description                                  | Default      |
 | ------------------- | -------- | -------------------------------------------- | ------------ |
 | `token`             | Yes      | A GitHub token with the required permissions | NA           |
-| `project-number`    | No       | A project number of the project board        | 66           |
-| `column-name`       | No       | Name of column to move to                    | released     |
+| `project-number`    | No       | A project number of the project board        | 188          |
+| `column-name`       | No       | Name of column to move to                    | Released     |
 | `head`              | No       | A head branch to sync from                   | main         |
 | `base`              | No       | A target branch for the created pull request | develop      |
-| `pr-team-reviewers` | No       | Reviewers to tag on the created pull request | axe-api-team |
+| `pr-team-reviewers` | No       | Reviewers to tag on the created pull request | results-team |
 
 ## Example usage
 

--- a/.github/actions/move-released-issues-and-create-sync-pr-v1/action.yml
+++ b/.github/actions/move-released-issues-and-create-sync-pr-v1/action.yml
@@ -8,11 +8,11 @@ inputs:
   project-number:
     description: 'A project number of the project board'
     required: false
-    default: '66'
+    default: '188'
   column-name:
     description: 'Name of column to move to'
     required: false
-    default: 'released'
+    default: 'Released'
   head:
     description: 'A head branch to sync from'
     required: false
@@ -24,7 +24,7 @@ inputs:
   pr-team-reviewers:
     description: 'Reviewers to tag on the created pull request'
     required: false
-    default: axe-api-team
+    default: 'results-team'
 
 runs:
   using: 'composite'

--- a/.github/actions/release-candidate-ready-for-qa-v1/action.yml
+++ b/.github/actions/release-candidate-ready-for-qa-v1/action.yml
@@ -46,12 +46,12 @@ runs:
       run: gh issue comment ${{ steps.get-release-issue.outputs.issue-url }} --body "$BODY"
       env:
         BODY: "Please use the release candidate build: ${{ steps.set-build-name.outputs.build-name }}"
-      # Move an issue to the "In QA" column on the board project #103
+      # Move an issue to the "QAToDo" column on the board project #188
     - uses: dequelabs/axe-api-team-public/.github/actions/add-to-board-v1@main
       with:
         issue-urls: ${{ steps.get-release-issue.outputs.issue-url }}
-        project-number: 103
-        column-name: In QA
+        project-number: 188
+        column-name: QAToDo
     - name: Slack notification
       uses: rtCamp/action-slack-notify@b24d75fe0e728a4bf9fc42ee217caa686d141ee8 # tag=v2.2.1
       env:
@@ -61,5 +61,5 @@ runs:
           *Build:* ${{ steps.set-build-name.outputs.build-name }}
         SLACK_COLOR: ${{ job.status }}
         MSG_MINIMAL: 'true'
-        SLACK_CHANNEL: api-team-releases
+        SLACK_CHANNEL: results-team-dev
         SLACK_WEBHOOK: ${{ inputs.slack-webhook }}


### PR DESCRIPTION
Changed all the action and workflow files to work with the new `team-results` board and Slack channel

Closes: [#4](https://github.com/dequelabs/results-team/issues/4)