### PR TITLE
refactor(action): refactor the GHA `check-and-move-issue-based-on-labels-v1`

### DIFF
--- a/.github/actions/check-and-move-issue-based-on-labels-v1/dist/check-and-move-issue-based-on-labels-v1/src/getIssueLabels.d.ts
+++ b/.github/actions/check-and-move-issue-based-on-labels-v1/dist/check-and-move-issue-based-on-labels-v1/src/getIssueLabels.d.ts
@@ -1,0 +1,33 @@
+import { getOctokit } from '@actions/github';
+interface GetIssueLabelsArgs {
+    issueOwner: string;
+    issueRepo: string;
+    issueNumber: number;
+    octokit: ReturnType<typeof getOctokit>;
+}
+export interface LabelNode {
+    name: string;
+}
+export interface projectItemsNode {
+    id: string;
+    project: {
+        number: number;
+    };
+}
+export interface GetIssueLabelsResult {
+    repository: {
+        issue: {
+            id: string;
+            number: number;
+            url: string;
+            labels: {
+                nodes: LabelNode[];
+            };
+            projectItems: {
+                nodes: projectItemsNode[];
+            };
+        };
+    };
+}
+export default function getIssueLabels({ issueOwner, issueRepo, issueNumber, octokit }: GetIssueLabelsArgs): Promise<GetIssueLabelsResult>;
+export {};

--- a/.github/actions/check-and-move-issue-based-on-labels-v1/dist/check-and-move-issue-based-on-labels-v1/src/types.d.ts
+++ b/.github/actions/check-and-move-issue-based-on-labels-v1/dist/check-and-move-issue-based-on-labels-v1/src/types.d.ts
@@ -8,27 +8,3 @@ export interface Field {
     type: string;
     options: Omit<Field, 'options' | 'type'>[];
 }
-export interface LabelNode {
-    name: string;
-}
-export interface projectItemsNode {
-    id: string;
-    project: {
-        number: number;
-    };
-}
-export interface IssueNodes {
-    repository: {
-        issue: {
-            id: string;
-            number: number;
-            url: string;
-            labels: {
-                nodes: LabelNode[];
-            };
-            projectItems: {
-                nodes: projectItemsNode[];
-            };
-        };
-    };
-}

--- a/.github/actions/check-and-move-issue-based-on-labels-v1/src/getIssueLabels.test.ts
+++ b/.github/actions/check-and-move-issue-based-on-labels-v1/src/getIssueLabels.test.ts
@@ -1,0 +1,85 @@
+import 'mocha'
+import sinon from 'sinon'
+import { assert } from 'chai'
+import { getOctokit } from '@actions/github'
+import getIssueLabels, { GetIssueLabelsResult } from './getIssueLabels'
+
+const MOCK_ISSUES: GetIssueLabelsResult = {
+  repository: {
+    issue: {
+      id: 'I_kwDOLYvJE86pLaA1',
+      number: 1,
+      url: 'https://github.com/dequelabs/repo/issues/1',
+      labels: {
+        nodes: [
+          {
+            name: 'some-label'
+          }
+        ]
+      },
+      projectItems: {
+        nodes: [
+          {
+            id: 'PVTI_lADOAD55W84AjfJEzgYzmqU4',
+            project: {
+              number: 123
+            }
+          },
+          {
+            id: 'PVTI_lADOAD55W84Aj5R-zgYzmqZ1',
+            project: {
+              number: 456
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+describe('getIssueLabels', () => {
+  let octokit: ReturnType<typeof getOctokit>
+
+  beforeEach(() => {
+    octokit = getOctokit('token')
+  })
+
+  afterEach(sinon.restore)
+
+  it('should return issues with their labels', async () => {
+    sinon.stub(octokit, 'graphql').resolves(MOCK_ISSUES)
+
+    const result = await getIssueLabels({
+      issueOwner: 'owner',
+      issueRepo: 'repo',
+      issueNumber: 1,
+      octokit
+    })
+
+    assert.deepEqual(result, MOCK_ISSUES)
+  })
+
+  describe('when an error occurs', () => {
+    it('should throw an error', async () => {
+      const errorMessage = 'some error'
+
+      sinon.stub(octokit, 'graphql').throws(new Error(errorMessage))
+
+      let error: Error | null = null
+
+      try {
+        await getIssueLabels({
+          issueOwner: 'owner',
+          issueRepo: 'repo',
+          issueNumber: 1,
+          octokit
+        })
+      } catch (err) {
+        error = err as Error
+      }
+
+      assert.isNotNull(error)
+      assert.include(error?.message, errorMessage)
+    })
+  })
+})

--- a/.github/actions/check-and-move-issue-based-on-labels-v1/src/getIssueLabels.ts
+++ b/.github/actions/check-and-move-issue-based-on-labels-v1/src/getIssueLabels.ts
@@ -1,0 +1,113 @@
+import { getOctokit } from '@actions/github'
+
+interface GetIssueLabelsArgs {
+  issueOwner: string
+  issueRepo: string
+  issueNumber: number
+  octokit: ReturnType<typeof getOctokit>
+}
+export interface LabelNode {
+  name: string
+}
+export interface projectItemsNode {
+  id: string
+  project: {
+    number: number
+  }
+}
+export interface GetIssueLabelsResult {
+  repository: {
+    issue: {
+      id: string
+      number: number
+      url: string
+      labels: {
+        nodes: LabelNode[]
+      }
+      projectItems: {
+        nodes: projectItemsNode[]
+      }
+    }
+  }
+}
+
+/**
+ * GraphQL query response:
+ * @example
+ * ```json
+ * {
+ *   "repository": {
+ *     "issue": {
+ *       "id": "I_kwDOLYvJE86pLaA1",
+ *       "number": 1,
+ *       "url": "https://github.com/dequelabs/repo/issues/1",
+ *       "labels": {
+ *         "nodes": [
+ *           {
+ *             "name": "some-label"
+ *           }
+ *         ]
+ *       },
+ *       "projectItems": {
+ *         "nodes": [
+ *           {
+ *             "id": "PVTI_lADOAD55W84AjfJEzgYzmqU4",
+ *             "project": {
+ *               "number": 123
+ *             }
+ *           },
+ *           {
+ *             "id": "PVTI_lADOAD55W84Aj5R-zgYzmqZ1",
+ *             "project": {
+ *               "number": 456
+ *             }
+ *           }
+ *         ]
+ *       }
+ *     }
+ *   }
+ * }
+ * ```
+ */
+
+export default async function getIssueLabels({
+  issueOwner,
+  issueRepo,
+  issueNumber,
+  octokit
+}: GetIssueLabelsArgs): Promise<GetIssueLabelsResult> {
+  try {
+    return octokit.graphql(
+      `
+      query {
+        repository(owner: "${issueOwner}", name: "${issueRepo}") {
+          issue(number: ${issueNumber}) {
+            id
+            number
+            url
+            labels(first: 20) {
+              nodes {
+                name
+              }
+            }
+            projectItems(first: 10) {
+              nodes {
+                id
+                project {
+                  number
+                }
+              }
+            }
+          }
+        }
+      }
+    `
+    )
+  } catch (error) {
+    throw new Error(
+      `Failed to get the issue's labels "https://github.com/${issueOwner}/${issueRepo}/issues/${issueNumber}": ${
+        (error as Error).message
+      }`
+    )
+  }
+}

--- a/.github/actions/check-and-move-issue-based-on-labels-v1/src/run.test.ts
+++ b/.github/actions/check-and-move-issue-based-on-labels-v1/src/run.test.ts
@@ -2,8 +2,9 @@ import 'mocha'
 import { assert } from 'chai'
 import sinon from 'sinon'
 import proxyquire from 'proxyquire'
-import { Core, GitHub, IssueNodes } from './types'
+import { Core, GitHub } from './types'
 import type { default as runType } from './run'
+import type { GetIssueLabelsResult } from './getIssueLabels'
 
 const ghToken = 'github token'
 const owner = 'owner_name'
@@ -41,7 +42,7 @@ const FIELD_LIST_MOCK = {
   ],
   totalCount: 1
 }
-const ISSUES_NODE_MOCK: IssueNodes = {
+const ISSUES_NODE_MOCK: GetIssueLabelsResult = {
   repository: {
     issue: {
       id: 'I_kwDOLYvJE86pLaF5',
@@ -306,7 +307,7 @@ describe('run', () => {
   describe('given the required inputs', () => {
     describe('when an issue is not found in the project board', () => {
       it('throws an error', async () => {
-        const ISSUES_NODE_MOCK_NO_ISSUE: IssueNodes = JSON.parse(
+        const ISSUES_NODE_MOCK_NO_ISSUE: GetIssueLabelsResult = JSON.parse(
           JSON.stringify(ISSUES_NODE_MOCK)
         )
 
@@ -329,7 +330,7 @@ describe('run', () => {
 
     describe('when an issue does not have any label', () => {
       it(`throws an error`, async () => {
-        const ISSUES_NODE_MOCK_NO_LABELS: IssueNodes = JSON.parse(
+        const ISSUES_NODE_MOCK_NO_LABELS: GetIssueLabelsResult = JSON.parse(
           JSON.stringify(ISSUES_NODE_MOCK)
         )
 
@@ -352,9 +353,8 @@ describe('run', () => {
 
     describe('when an issue does not have a team label', () => {
       it(`throws an error`, async () => {
-        const ISSUES_NODE_MOCK_NO__TEAM_LABEL: IssueNodes = JSON.parse(
-          JSON.stringify(ISSUES_NODE_MOCK)
-        )
+        const ISSUES_NODE_MOCK_NO__TEAM_LABEL: GetIssueLabelsResult =
+          JSON.parse(JSON.stringify(ISSUES_NODE_MOCK))
 
         ISSUES_NODE_MOCK_NO__TEAM_LABEL.repository.issue.labels.nodes.shift()
 
@@ -424,7 +424,7 @@ describe('run', () => {
 
       describe('and an issue does not have one of the provided labels', () => {
         it(`should NOT be moved`, async () => {
-          const ISSUES_NODE_NOT_MOVE_MOCK: IssueNodes = JSON.parse(
+          const ISSUES_NODE_NOT_MOVE_MOCK: GetIssueLabelsResult = JSON.parse(
             JSON.stringify(ISSUES_NODE_MOCK)
           )
 
@@ -502,7 +502,7 @@ describe('run', () => {
 
       describe('and an issue does not have all the provided labels', () => {
         it(`should NOT be moved`, async () => {
-          const ISSUES_NODE_NOT_MOVE_MOCK: IssueNodes = JSON.parse(
+          const ISSUES_NODE_NOT_MOVE_MOCK: GetIssueLabelsResult = JSON.parse(
             JSON.stringify(ISSUES_NODE_MOCK)
           )
 
@@ -536,9 +536,8 @@ describe('run', () => {
 
       describe('and an issue does not have at least one of the excluded labels', () => {
         it(`should be moved to the target column "${targetColumnName}"`, async () => {
-          const ISSUES_NODE_ONE_EXCLUDED_LABEL_MOCK: IssueNodes = JSON.parse(
-            JSON.stringify(ISSUES_NODE_MOCK)
-          )
+          const ISSUES_NODE_ONE_EXCLUDED_LABEL_MOCK: GetIssueLabelsResult =
+            JSON.parse(JSON.stringify(ISSUES_NODE_MOCK))
 
           ISSUES_NODE_ONE_EXCLUDED_LABEL_MOCK.repository.issue.labels.nodes.push(
             {
@@ -590,9 +589,8 @@ describe('run', () => {
 
       describe('and an issue has all of the excluded labels', () => {
         it(`should NOT be moved`, async () => {
-          const ISSUES_NODE_ALL_EXCLUDED_LABEL_MOCK: IssueNodes = JSON.parse(
-            JSON.stringify(ISSUES_NODE_MOCK)
-          )
+          const ISSUES_NODE_ALL_EXCLUDED_LABEL_MOCK: GetIssueLabelsResult =
+            JSON.parse(JSON.stringify(ISSUES_NODE_MOCK))
 
           ISSUES_NODE_ALL_EXCLUDED_LABEL_MOCK.repository.issue.labels.nodes.push(
             {
@@ -676,7 +674,7 @@ describe('run', () => {
       describe('and an issue has one of the provided labels', () => {
         describe('and does not have at least one of the excluded labels', () => {
           it(`should be moved to the target column "${targetColumnName}"`, async () => {
-            const ISSUES_NODE_WITH_ONE_EXCLUDED_LABEL_MOCK: IssueNodes =
+            const ISSUES_NODE_WITH_ONE_EXCLUDED_LABEL_MOCK: GetIssueLabelsResult =
               JSON.parse(JSON.stringify(ISSUES_NODE_MOCK))
 
             ISSUES_NODE_WITH_ONE_EXCLUDED_LABEL_MOCK.repository.issue.labels.nodes.push(

--- a/.github/actions/check-and-move-issue-based-on-labels-v1/src/types.ts
+++ b/.github/actions/check-and-move-issue-based-on-labels-v1/src/types.ts
@@ -13,27 +13,3 @@ export interface Field {
   type: string
   options: Omit<Field, 'options' | 'type'>[]
 }
-export interface LabelNode {
-  name: string
-}
-export interface projectItemsNode {
-  id: string
-  project: {
-    number: number
-  }
-}
-export interface IssueNodes {
-  repository: {
-    issue: {
-      id: string
-      number: number
-      url: string
-      labels: {
-        nodes: LabelNode[]
-      }
-      projectItems: {
-        nodes: projectItemsNode[]
-      }
-    }
-  }
-}


### PR DESCRIPTION
Move the logic of getting issue details to the separate function `getIssueLabels` to reuse it in another GHA.

No QA needed