### PR TITLE
chore: Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 * @dequelabs/results-team
-* @dequelabs/ocarina-team 
+* @dequelabs/ocarina-team


### PR DESCRIPTION
Updating with shared ownership and changing to the `ocarina-team` rather than the `api-team`

No QA required