### PR TITLE
chore: fix dependabot to update all actions action.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,9 +2,9 @@ version: 2
 
 updates:
   - package-ecosystem: 'github-actions'
-    directory: '/'
-    schedule:
-      interval: 'monthly'
+    directories:
+      - '/'
+      - '/.github/actions/**/*'
     open-pull-requests-limit: 10
     commit-message:
       prefix: 'chore'


### PR DESCRIPTION
According to https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#directories-or-directory--, dependabot is not updating any of our actions in the .github/actions directory as it only looks for the `action.yml` file in the root dir. Depending how github defines the "root dir" this could or could not work. Testing to see if this syntax will allow dependabot to update all the actions `action.yml` files.

Temporarily took away the interval setting so we could see if thins works without waiting a month.

No QA required