### PR TITLE
chore: try again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     directories:
       - '/'
       - '/.github/actions/**/*'
+    schedule:
+      interval: 'cron'
+      cronjob: '*/5 * * * *'
     open-pull-requests-limit: 10
     commit-message:
       prefix: 'chore'


### PR DESCRIPTION
Apparently `schedule` is required though it doesn't seem github checks the file before allowing you to merge (like it would a codeowner file).

> Dependabot encountered the following error when parsing your .github/dependabot.yml:
>
> The property '#/updates/0' did not contain a required property of 'schedule'
Please update the config file to conform with Dependabot's specification.
