### PR TITLE
chore: dependabot schedule cannot be <24 hours

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       - '/.github/actions/**/*'
     schedule:
       interval: 'cron'
-      cronjob: '*/5 * * * *'
+      cronjob: '30 17 * * *'
     open-pull-requests-limit: 10
     commit-message:
       prefix: 'chore'


### PR DESCRIPTION
sigh

> The cron expression at property '#/updates/0/schedule/interval/cronjob' must have a minimum period of 24 hours between next job run.

No QA required