### PR TITLE
fix: update to use node 22 in actions

### DIFF
--- a/.github/actions/create-update-axe-core-pull-request-v1/action.yml
+++ b/.github/actions/create-update-axe-core-pull-request-v1/action.yml
@@ -25,7 +25,7 @@ runs:
       if: ${{ inputs.should-setup-node == 'true' }}
       uses: actions/setup-node@v5
       with:
-        node-version: 18
+        node-version: 22
     - id: update-axe-core
       uses: dequelabs/axe-api-team-public/.github/actions/update-axe-core-v1@main
     - name: Open PR

--- a/.github/actions/update-axe-core-v1/README.md
+++ b/.github/actions/update-axe-core-v1/README.md
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
       - id: update
         uses: dequelabs/axe-api-team-public/.github/actions/update-axe-core-v1@main
 ```

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
       - run: npm ci
       - run: npm run lint -ws
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
       - run: npm ci
       - run: npm run coverage --workspace=semantic-pr-footer-v1
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
       - run: npm ci
       - run: npm run coverage --workspace=is-release-week-v1
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
       - run: npm ci
       - run: npm run coverage --workspace=is-release-in-progress-v1
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
       - run: npm ci
       - run: npm run coverage --workspace=has-auto-releasable-commits-v1
@@ -79,7 +79,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
       - run: npm ci
       - run: npm run coverage --workspace=generate-commit-list-v1
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
       - run: npm ci
       - run: npm run coverage --workspace=add-to-board-v1
@@ -105,7 +105,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
       - run: npm ci
       - run: npm run coverage --workspace=label-and-move-released-issues-v1
@@ -118,7 +118,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
       - run: npm ci
       - run: npm run coverage --workspace=require-multiple-reviewers-v1
@@ -131,7 +131,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
       - run: npm ci
       - run: npm run coverage --workspace=update-axe-core-v1
@@ -144,7 +144,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
       - run: npm ci
       - run: npm run coverage --workspace=get-release-issue-v1
@@ -157,7 +157,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
       - run: npm ci
       - run: npm run coverage --workspace=get-new-env-vars-v1

--- a/.github/workflows/update-generated-files.yml
+++ b/.github/workflows/update-generated-files.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
 
       - name: Build


### PR DESCRIPTION
Updates our actions to use node 22 (instead of 18/20). Unfortunately composite actions cannot do the same since the [actions/runner does not support it](https://github.com/actions/runner/issues/3600). We'll have to use `node24` when we update to that.

No QA required