### PR TITLE
chore: fix codeowners syntax

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @dequelabs/results-team
-* @dequelabs/ocarina-team
+* @dequelabs/results-team @dequelabs/ocarina-team


### PR DESCRIPTION
The previous syntax was two lines defining everything. Thus, only the last entry would take effect. This patch correctly provides both teams to one definition. Meaning both teams share the entire project instead of just the last defined.

No QA Required