### PR TITLE
chore: allow generated files to be dispatched

### DIFF
--- a/.github/workflows/update-generated-files.yml
+++ b/.github/workflows/update-generated-files.yml
@@ -1,6 +1,7 @@
 name: Update generated files
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
This patch allows for the generated files to be updated on request instead of needing to rerun a recent merge to get the same thing done.

No QA Required