### PR TITLE
feat(workflow): added `results-team-project-management.yml` workflow

### DIFF
--- a/.github/workflows/results-team-project-management.yml
+++ b/.github/workflows/results-team-project-management.yml
@@ -8,7 +8,7 @@ concurrency:
   # Cancel in-progress runs only for the exact same event on the same issue/PR.
   # e.g. two 'labeled' events with the same label on the same issue will cancel the previous,
   # but 'closed' and 'labeled' or two different labels will run in parallel.
-  group: "${{ github.workflow }}-${{ github.event.action }}-${{ github.event.label.name || '' }}-${{ github.event.issue.number || github.event.pull_request.number }}"
+  group: "${{ github.workflow }}-${{ github.event.action }}-${{ github.event.label.name || '' }}-${{ github.event.issue.number }}"
   cancel-in-progress: true
 
 jobs:
@@ -40,14 +40,6 @@ jobs:
     with:
       issue-number: ${{ github.event.issue.number }}
       repo-name: ${{ github.event.repository.name }}
-      repo-owner: ${{ github.event.repository.owner.login }}
-    secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}
-
-  set-pr-reviewer:
-    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
-    uses: dequelabs/results-team/.github/workflows/set-pr-reviewer-based-on-issue-label.yml@main
-    with:
-      pull-request-number: ${{ github.event.pull_request.number }}
+      repo-owner: ${{ github.repository_owner }}
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The idea is to create a single workflow `results-team-project-management.yml` (caller) that runs other workflows. So we have to copy one caller workflow in each of our repos to run 4 workflows.

> [!WARNING]
> This PR must be merged after results-team:
> - https://github.com/dequelabs/results-team/pull/272

Ref: [#209](https://github.com/dequelabs/results-team/issues/209)