### PR TITLE
feat: add version-package-path input

### DIFF
--- a/.github/actions/create-release-v1/action.yml
+++ b/.github/actions/create-release-v1/action.yml
@@ -12,6 +12,9 @@ inputs:
     description: The directory containing the database migrations e.g. src/database/migrations
   env-file-path:
     description: The path to the `.env` file e.g. src/service/sample.env
+  version-package-path:
+    description: 'The path to the package.json or lerna.json file that contains the version number to be released'
+    required: false
 
 runs:
   using: 'composite'
@@ -41,13 +44,24 @@ runs:
     - name: Get release version
       id: get_release_version
       shell: bash
+      env:
+        VERSION_PACKAGE_PATH: ${{ inputs.version-package-path }}
       run: |
+        # Get the version number from the prepare_release shell script and set it as an output
         # Monorepos have a lerna.json file that contains the updated version number
         # Non-monorepos, or non-npm repos, have a package.json file that contains the updated version number
-        if [ -f "lerna.json" ]; then
-          echo "RELEASE_VERSION=$(cat lerna.json | jq -r '.version')" >> $GITHUB_OUTPUT
+        if [ -n "$VERSION_PACKAGE_PATH" ]; then
+          if [ -f "$VERSION_PACKAGE_PATH" ]; then
+            version="$(jq -r '.version' "$VERSION_PACKAGE_PATH")"
+            echo "RELEASE_VERSION=$version" >> "$GITHUB_OUTPUT"
+          else
+            echo "version-package-path was provided but file does not exist: $VERSION_PACKAGE_PATH" >&2
+            exit 1
+          fi
+        elif [ -f "lerna.json" ]; then
+          echo "RELEASE_VERSION=$(jq -r '.version' lerna.json)" >> $GITHUB_OUTPUT
         else
-          echo "RELEASE_VERSION=$(cat package.json | jq -r '.version')" >> $GITHUB_OUTPUT
+          echo "RELEASE_VERSION=$(jq -r '.version' package.json)" >> $GITHUB_OUTPUT
         fi
 
     - name: Get CHANGELOG changes

--- a/.github/actions/create-release-v1/action.yml
+++ b/.github/actions/create-release-v1/action.yml
@@ -62,7 +62,7 @@ runs:
           version="$(jq -r '.version' package.json)"
         fi
         if [ -z "$version" ] || [ "$version" = "null" ]; then
-          echo "Could not extract a valid version from the package file" >&2
+          echo "Could not extract a valid version from the version property of the package file" >&2
           exit 1
         fi
         echo "RELEASE_VERSION=$version" >> "$GITHUB_OUTPUT"

--- a/.github/actions/create-release-v1/action.yml
+++ b/.github/actions/create-release-v1/action.yml
@@ -52,16 +52,20 @@ runs:
         if [ -n "$VERSION_PACKAGE_PATH" ]; then
           if [ -f "$VERSION_PACKAGE_PATH" ]; then
             version="$(jq -r '.version' "$VERSION_PACKAGE_PATH")"
-            echo "RELEASE_VERSION=$version" >> "$GITHUB_OUTPUT"
           else
             echo "version-package-path was provided but file does not exist: $VERSION_PACKAGE_PATH" >&2
             exit 1
           fi
         elif [ -f "lerna.json" ]; then
-          echo "RELEASE_VERSION=$(jq -r '.version' lerna.json)" >> $GITHUB_OUTPUT
+          version="$(jq -r '.version' lerna.json)"
         else
-          echo "RELEASE_VERSION=$(jq -r '.version' package.json)" >> $GITHUB_OUTPUT
+          version="$(jq -r '.version' package.json)"
         fi
+        if [ -z "$version" ] || [ "$version" = "null" ]; then
+          echo "Could not extract a valid version from the package file" >&2
+          exit 1
+        fi
+        echo "RELEASE_VERSION=$version" >> "$GITHUB_OUTPUT"
 
     - name: Get CHANGELOG changes
       shell: bash

--- a/.github/actions/create-release-v1/action.yml
+++ b/.github/actions/create-release-v1/action.yml
@@ -47,7 +47,6 @@ runs:
       env:
         VERSION_PACKAGE_PATH: ${{ inputs.version-package-path }}
       run: |
-        # Get the version number from the prepare_release shell script and set it as an output
         # Monorepos have a lerna.json file that contains the updated version number
         # Non-monorepos, or non-npm repos, have a package.json file that contains the updated version number
         if [ -n "$VERSION_PACKAGE_PATH" ]; then


### PR DESCRIPTION
Adds `version-package-path` in the create-release action to allow the path to the package containing the version to be passed. Parallel change to the one in the create-release-candidate action, #330.

No QA required