### PR TITLE
feat: validate create-release-candidate version

### DIFF
--- a/.github/actions/create-release-candidate-v1/action.yml
+++ b/.github/actions/create-release-candidate-v1/action.yml
@@ -119,16 +119,20 @@ runs:
         if [ -n "$VERSION_PACKAGE_PATH" ]; then
           if [ -f "$VERSION_PACKAGE_PATH" ]; then
             version="$(jq -r '.version' "$VERSION_PACKAGE_PATH")"
-            echo "version=$version" >> "$GITHUB_OUTPUT"
           else
             echo "version-package-path was provided but file does not exist: $VERSION_PACKAGE_PATH" >&2
             exit 1
           fi
         elif [ -f "lerna.json" ]; then
-          echo "version=$(jq -r '.version' lerna.json)" >> $GITHUB_OUTPUT
+          version="$(jq -r '.version' lerna.json)"
         else
-          echo "version=$(jq -r '.version' package.json)" >> $GITHUB_OUTPUT
+          version="$(jq -r '.version' package.json)"
         fi
+        if [ -z "$version" ] || [ "$version" = "null" ]; then
+          echo "Could not extract a valid version from the package file" >&2
+          exit 1
+        fi
+        echo "version=$version" >> "$GITHUB_OUTPUT"
 
     # https://github.com/dequelabs/axe-core-npm/blob/62fd241fb3748ca8ce4adb30d7976947ccaa18ee/.github/workflows/create-release.yml#L32-L57
     - name: Create release commit


### PR DESCRIPTION
Throws if the release-candidate-version does not exist or is null.

No QA required.