### PR TITLE
feat(release-candidate-ready-for-qa-v1): add send-slack-notification input

### DIFF
--- a/.github/actions/release-candidate-ready-for-qa-v1/README.md
+++ b/.github/actions/release-candidate-ready-for-qa-v1/README.md
@@ -4,13 +4,14 @@ A GitHub Action that lets the QA team know a release candidate is ready for QA
 
 ## Inputs
 
-| Name                           | Required | Description                                                                                       | Default                      |
-| ------------------------------ | -------- | ------------------------------------------------------------------------------------------------- | ---------------------------- |
-| `sha-rc`                       | No       | 8 characters SHA of the release commit from the release branch                                    | git rev-parse --short=8 HEAD |
-| `slack-webhook`                | No       | A Slack channel webhook URL where the message will be sent if provided                            | NA                           |
-| `slack-channel`                | No       | A Slack channel where the message will be sent if provided                                        | NA                           |
-| `release-issue-project-number` | No       | GitHub Project number that the release issue will be added to                                     | NA                           |
-| `release-issue-column-name`    | No       | The column name within the GitHub Project that the release issue will be added to (e.g. "QAToDo") | NA                           |
+| Name                           | Required | Description                                                                                                                             | Default                      |
+| ------------------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| `sha-rc`                       | No       | 8 characters SHA of the release commit from the release branch                                                                          | git rev-parse --short=8 HEAD |
+| `slack-webhook`                | No       | A Slack channel webhook URL where the message will be sent if provided                                                                  | NA                           |
+| `slack-channel`                | No       | A Slack channel where the message will be sent if provided                                                                              | NA                           |
+| `release-issue-project-number` | No       | GitHub Project number that the release issue will be added to                                                                           | NA                           |
+| `release-issue-column-name`    | No       | The column name within the GitHub Project that the release issue will be added to (e.g. "QAToDo")                                       | NA                           |
+| `send-slack-notification`      | No       | Whether to send the built-in Slack notification. Set to `'false'` to opt out (e.g. when notifications are handled by another workflow). | `'true'`                     |
 
 ## Example usage
 

--- a/.github/actions/release-candidate-ready-for-qa-v1/action.yml
+++ b/.github/actions/release-candidate-ready-for-qa-v1/action.yml
@@ -17,6 +17,10 @@ inputs:
   release-issue-column-name:
     description: The column name within the GitHub Project that the release issue will be added to (e.g. "QAToDo")
     required: false
+  send-slack-notification:
+    description: Whether to send the built-in Slack notification. Set to "false" to opt out (e.g. when notifications are handled by another workflow).
+    required: false
+    default: 'true'
 
 runs:
   using: 'composite'
@@ -63,7 +67,7 @@ runs:
         project-number: ${{ inputs.release-issue-project-number }}
         column-name: ${{ inputs.release-issue-column-name }}
     - name: Slack notification
-      if: inputs.slack-channel != '' && inputs.slack-webhook != ''
+      if: inputs.send-slack-notification == 'true' && inputs.slack-channel != '' && inputs.slack-webhook != ''
       uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # tag=v2.3.3
       env:
         SLACK_TITLE: 'RC: "${{ steps.set-build-name.outputs.build-name }}" is ready for QA:'


### PR DESCRIPTION
## Summary

- Adds a `send-slack-notification` input (default `'true'`) to the `release-candidate-ready-for-qa-v1` composite action so consumers can opt out of the built-in Slack notification.
- Updates README with the new input.

### Why

Some consumers (e.g. `dequelabs/jazzband`) already handle failure/status notifications via a separate workflow living in a private repo. Today the action either forces the built-in `rtCamp/action-slack-notify` step to fire (double-notifying), or requires callers to drop `slack-webhook` + `slack-channel` entirely. This input makes the opt-out explicit.

Default remains `'true'`, so existing consumers are unaffected.

## Test plan

- [ ] Consumer (jazzband) sets `send-slack-notification: 'false'` and confirms the Slack step is skipped while the rest of the action (issue comment, add-to-board) still runs.
- [ ] Existing consumers that don't pass the input continue to receive Slack notifications as before.

No QA Needed