### PR TITLE
chore(dependabot): ignore @actions/github >=9 (ESM-only)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,8 @@ updates:
         versions: ['>=5']
       - dependency-name: 'conventional-commits-parser'
         versions: ['>=6']
+      - dependency-name: '@actions/github'
+        versions: ['>=9']
     groups:
       # Any updates not caught by the group config will get individual PRs
       npm-low-risk:


### PR DESCRIPTION
## Summary
- `@actions/github` v9 is ESM-only (`"type": "module"`, no `require` condition in `exports`), but every workspace in this repo is CommonJS — `tsconfig.json` sets `module: "commonjs"`, mocha uses `ts-node/register`, and 67 TS files `import` from `@actions/github`.
- Dependabot PR #316 fails CI with `ERR_PACKAGE_PATH_NOT_EXPORTED` when ts-node-transpiled CJS calls `require('@actions/github')`.
- Pinning below the ESM-only major mirrors the existing entries for `chai` (>=5) and `conventional-commits-parser` (>=6).

Closing #316 alongside this.

## Test plan
- [ ] Dependabot run on the next monthly schedule does not re-propose `@actions/github@>=9`
- [ ] `@actions/github@^7` minor/patch updates still come through normally

No QA required