### PR TITLE
chore(dependabot): ignore @actions/exec >= 3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,8 @@ updates:
         versions: ['>=6']
       - dependency-name: '@actions/github'
         versions: ['>=9']
+      - dependency-name: '@actions/exec'
+        versions: ['>=3']
     groups:
       # Any updates not caught by the group config will get individual PRs
       npm-low-risk:


### PR DESCRIPTION
@actions/exec 3.0.0 [is now esm only](https://github.com/actions/toolkit/blob/8066c8132268398c77366dae936dac12c03d39ee/packages/exec/RELEASES.md#300)

No QA Required