### PR TITLE
feat(semantic-pr-footer): accept QA notes as a trailing section

### DIFF
--- a/.github/actions/semantic-pr-footer-v1/README.md
+++ b/.github/actions/semantic-pr-footer-v1/README.md
@@ -46,3 +46,28 @@ The footer of a PR will fail unless it [_starts with_ one of the following strin
 - "qa notes: "
 - "no qa required"
 - "no qa needed"
+
+Markdown is tolerated, so a footer may be written as a heading or with emphasis —
+`## QA Notes: verify X`, `**No QA required**` — and the leading `#`s or `*`s are
+ignored when matching.
+
+### QA notes as a trailing section
+
+QA notes may also be written as the last section of the body, with the detail
+underneath the heading rather than on one line:
+
+```markdown
+This PR does some things.
+
+## QA Notes
+
+Build the binary, then confirm it starts and writes a report.
+```
+
+This is only checked if the last line is not itself a valid footer, so existing
+single-line footers behave exactly as before. Two constraints:
+
+- **The section must have content.** A bare `## QA Notes` with nothing beneath it
+  fails — a heading promising QA notes that never arrive is not a footer.
+- **Only "qa notes" may stand alone this way.** Issue-linking keywords still need
+  their reference on the same line, so `## Closes` with `#123` beneath it fails.

--- a/.github/actions/semantic-pr-footer-v1/dist/index.js
+++ b/.github/actions/semantic-pr-footer-v1/dist/index.js
@@ -25590,13 +25590,22 @@ var validFooterPrefixes = [
   "qa notes"
 ];
 var validFooters = ["no qa needed", "no qa required"];
+var validSectionHeadings = ["qa notes"];
 var validFooterPrefixRegex = new RegExp(
   `^(${validFooterPrefixes.join("|")}):? `,
   "i"
 );
 var validFooterRegex = new RegExp(`^(${validFooters.join("|")})`, "i");
-function isValidFooter(footer) {
-  return validFooterRegex.test(footer) || validFooterPrefixRegex.test(footer);
+var validSectionHeadingRegex = new RegExp(
+  `^(${validSectionHeadings.join("|")}):?\\s*$`,
+  "i"
+);
+function stripMarkdown(footer) {
+  return footer.replace(/^#{1,6}\s*/, "").replace(/[*_`]/g, "").replace(/^\s+/, "");
+}
+function isValidFooter(footer, isSectionHeading = false) {
+  const text = stripMarkdown(footer);
+  return validFooterRegex.test(text) || validFooterPrefixRegex.test(text) || isSectionHeading && validSectionHeadingRegex.test(text);
 }
 
 // src/run.ts
@@ -25624,13 +25633,25 @@ function run(core, github) {
     const bodyLines = body.trim().split(/[\r\n]+/);
     const footer = bodyLines[bodyLines.length - 1];
     core.info(`Validating PR footer: "${footer}"`);
-    if (!isValidFooter(footer)) {
-      core.setFailed(
-        "PR footer does not close an issue (`Closes: `), reference an issue (`Ref: ` or `Refs: `), provide QA notes (`QA notes: `), or state that no QA is needed (`No QA needed` or `No QA required`)"
-      );
+    if (isValidFooter(footer)) {
+      core.info("Footer matches team policy");
       return;
     }
-    core.info("Footer matches team policy");
+    const headingIndex = bodyLines.findLastIndex(
+      (line) => /^#{1,6}\s+\S/.test(line)
+    );
+    const heading = headingIndex === -1 ? "" : bodyLines[headingIndex];
+    const sectionBody = bodyLines.slice(headingIndex + 1).join(" ").trim();
+    if (headingIndex !== -1 && sectionBody.length > 0) {
+      core.info(`Validating trailing section heading: "${heading}"`);
+      if (isValidFooter(heading, true)) {
+        core.info("Footer matches team policy");
+        return;
+      }
+    }
+    core.setFailed(
+      "PR footer does not close an issue (`Closes: `), reference an issue (`Ref: ` or `Refs: `), provide QA notes (`QA notes: `, or a trailing `## QA notes` section), or state that no QA is needed (`No QA needed` or `No QA required`)"
+    );
   } catch (error2) {
     core.setFailed(error2.message);
   }

--- a/.github/actions/semantic-pr-footer-v1/src/isValidFooter.test.ts
+++ b/.github/actions/semantic-pr-footer-v1/src/isValidFooter.test.ts
@@ -55,4 +55,40 @@ describe('isValidFooter', () => {
   it('ignores case', () => {
     assert.ok(isValidFooter('closes: '))
   })
+  describe('markdown', () => {
+    it('accepts a heading with a suffix on the same line', () => {
+      assert.ok(isValidFooter('## QA Notes: verify the thing'))
+    })
+
+    it('accepts a standalone footer written as a heading', () => {
+      assert.ok(isValidFooter('### No QA required'))
+    })
+
+    it('accepts an emphasised standalone footer', () => {
+      assert.ok(isValidFooter('**No QA needed**'))
+    })
+  })
+
+  describe('given a section heading', () => {
+    it('accepts a bare "QA notes" keyword', () => {
+      assert.ok(isValidFooter('## QA Notes', true))
+      assert.ok(isValidFooter('## QA notes:', true))
+      assert.ok(isValidFooter('QA notes', true))
+    })
+
+    it('still rejects issue-linking keywords, which need a reference', () => {
+      assert.ok(!isValidFooter('## Closes', true))
+      assert.ok(!isValidFooter('## Fixes', true))
+      assert.ok(!isValidFooter('## Refs', true))
+    })
+
+    it('rejects an unrelated heading', () => {
+      assert.ok(!isValidFooter('## Testing', true))
+    })
+  })
+
+  it('rejects a bare "QA notes" keyword outside a section heading', () => {
+    assert.ok(!isValidFooter('QA notes'))
+    assert.ok(!isValidFooter('## QA notes'))
+  })
 })

--- a/.github/actions/semantic-pr-footer-v1/src/isValidFooter.ts
+++ b/.github/actions/semantic-pr-footer-v1/src/isValidFooter.ts
@@ -20,11 +20,54 @@ const validFooterPrefixes = [
 // These may appear alone or with a suffix (eg, "no qa needed" or "no qa needed (test only)")
 const validFooters = ['no qa needed', 'no qa required']
 
+// These may appear alone *only* when they introduce a trailing section, so the
+// content satisfying them lives beneath the heading rather than on the same line.
+// Issue-linking keywords are deliberately excluded: "## Closes" with the issue
+// reference somewhere below is not something we want to accept.
+const validSectionHeadings = ['qa notes']
+
 const validFooterPrefixRegex = new RegExp(
   `^(${validFooterPrefixes.join('|')}):? `,
   'i'
 )
 const validFooterRegex = new RegExp(`^(${validFooters.join('|')})`, 'i')
-export default function isValidFooter(footer: string): boolean {
-  return validFooterRegex.test(footer) || validFooterPrefixRegex.test(footer)
+const validSectionHeadingRegex = new RegExp(
+  `^(${validSectionHeadings.join('|')}):?\\s*$`,
+  'i'
+)
+
+/**
+ * Strip markdown so a footer written as a heading is recognised: the leading `#`s
+ * of an ATX heading, and the emphasis characters people wrap keywords in
+ * (`**No QA required**`).
+ *
+ * Only leading whitespace is removed. The prefix rule requires whitespace after
+ * the keyword — "Closes:" alone is invalid — so trimming the end here would make
+ * every prefixed footer fail.
+ */
+function stripMarkdown(footer: string): string {
+  return footer
+    .replace(/^#{1,6}\s*/, '')
+    .replace(/[*_`]/g, '')
+    .replace(/^\s+/, '')
+}
+
+/**
+ * @param footer the candidate footer text
+ * @param isSectionHeading whether `footer` is a markdown heading introducing a
+ * non-empty trailing section. Only then may a keyword such as "QA notes" stand
+ * alone, because the content it promises follows underneath. Without this, a
+ * bare keyword stays invalid — "Closes:" on its own is still a failure.
+ */
+export default function isValidFooter(
+  footer: string,
+  isSectionHeading = false
+): boolean {
+  const text = stripMarkdown(footer)
+
+  return (
+    validFooterRegex.test(text) ||
+    validFooterPrefixRegex.test(text) ||
+    (isSectionHeading && validSectionHeadingRegex.test(text))
+  )
 }

--- a/.github/actions/semantic-pr-footer-v1/src/isValidFooter.ts
+++ b/.github/actions/semantic-pr-footer-v1/src/isValidFooter.ts
@@ -47,7 +47,7 @@ const validSectionHeadingRegex = new RegExp(
  */
 function stripMarkdown(footer: string): string {
   return footer
-    .replace(/^#{1,6}\s*/, '')
+    .replace(/^\s{0,3}#{1,6}\s*/, '')
     .replace(/[*_`]/g, '')
     .replace(/^\s+/, '')
 }

--- a/.github/actions/semantic-pr-footer-v1/src/run.test.ts
+++ b/.github/actions/semantic-pr-footer-v1/src/run.test.ts
@@ -234,4 +234,78 @@ describe('run', () => {
       setFailed.mock.calls.some(call => call.arguments[0] === 'failure!')
     )
   })
+  describe('trailing section footers', () => {
+    const runWith = (body: string) => {
+      const info = mock.fn<(message: string) => void>()
+      const setFailed = mock.fn<(message: string) => void>()
+      const core = {
+        info,
+        setFailed,
+        getInput: mock.fn<(name: string) => string>(() => '')
+      }
+      const github = {
+        context: { payload: { pull_request: { number: 1, body } } }
+      }
+
+      run(core as unknown as Core, github as unknown as GitHub)
+
+      return { info, setFailed }
+    }
+
+    const passed = (info: ReturnType<typeof mock.fn>) =>
+      info.mock.calls.some(
+        call => call.arguments[0] === 'Footer matches team policy'
+      )
+
+    const failedWithPolicyMessage = (
+      setFailed: ReturnType<typeof mock.fn>
+    ): boolean =>
+      setFailed.mock.calls.some(call =>
+        String(call.arguments[0]).includes('PR footer does not close an issue')
+      )
+
+    it('passes given a QA notes heading with content beneath it', () => {
+      const { info, setFailed } = runWith(
+        'This pr does some things.\n\n## QA Notes\n\nBuild the binary, then confirm it starts.'
+      )
+
+      assert.ok(passed(info))
+      assert.strictEqual(setFailed.mock.callCount(), 0)
+    })
+
+    it('passes given a lower-level heading', () => {
+      const { info } = runWith('Body.\n\n#### QA notes:\n\nRun the suite.')
+
+      assert.ok(passed(info))
+    })
+
+    it('fails given a QA notes heading with nothing beneath it', () => {
+      const { setFailed } = runWith('This pr does some things.\n\n## QA Notes')
+
+      assert.ok(failedWithPolicyMessage(setFailed))
+    })
+
+    it('fails given an unrelated trailing section', () => {
+      const { setFailed } = runWith('Body.\n\n## Testing\n\nSome prose.')
+
+      assert.ok(failedWithPolicyMessage(setFailed))
+    })
+
+    it('does not let a trailing section rescue an issue-linking keyword', () => {
+      const { setFailed } = runWith('Body.\n\n## Closes\n\n#123')
+
+      assert.ok(failedWithPolicyMessage(setFailed))
+    })
+
+    it('still prefers the single-line footer when present', () => {
+      const { info } = runWith('## QA Notes\n\nSome steps.\n\ncloses: #1')
+
+      assert.ok(
+        info.mock.calls.some(
+          call => call.arguments[0] === 'Validating PR footer: "closes: #1"'
+        )
+      )
+      assert.ok(passed(info))
+    })
+  })
 })

--- a/.github/actions/semantic-pr-footer-v1/src/run.ts
+++ b/.github/actions/semantic-pr-footer-v1/src/run.ts
@@ -39,14 +39,42 @@ export default function run(core: Core, github: GitHub) {
 
     core.info(`Validating PR footer: "${footer}"`)
 
-    if (!isValidFooter(footer)) {
-      core.setFailed(
-        'PR footer does not close an issue (`Closes: `), reference an issue (`Ref: ` or `Refs: `), provide QA notes (`QA notes: `), or state that no QA is needed (`No QA needed` or `No QA required`)'
-      )
+    if (isValidFooter(footer)) {
+      core.info('Footer matches team policy')
       return
     }
 
-    core.info('Footer matches team policy')
+    // Fall back to a trailing section, so QA notes can be written as a heading
+    // with the detail beneath it:
+    //
+    //   ## QA Notes
+    //
+    //   Build the binary, then confirm …
+    //
+    // Checked only after the single-line form fails, so nothing that passed
+    // before changes behaviour. The section must have content: a bare heading
+    // promising QA notes that never arrive is not a footer.
+    const headingIndex = bodyLines.findLastIndex(line =>
+      /^#{1,6}\s+\S/.test(line)
+    )
+    const heading = headingIndex === -1 ? '' : bodyLines[headingIndex]
+    const sectionBody = bodyLines
+      .slice(headingIndex + 1)
+      .join(' ')
+      .trim()
+
+    if (headingIndex !== -1 && sectionBody.length > 0) {
+      core.info(`Validating trailing section heading: "${heading}"`)
+
+      if (isValidFooter(heading, true)) {
+        core.info('Footer matches team policy')
+        return
+      }
+    }
+
+    core.setFailed(
+      'PR footer does not close an issue (`Closes: `), reference an issue (`Ref: ` or `Refs: `), provide QA notes (`QA notes: `, or a trailing `## QA notes` section), or state that no QA is needed (`No QA needed` or `No QA required`)'
+    )
   } catch (error) {
     core.setFailed((error as Error).message)
   }

--- a/.github/actions/semantic-pr-footer-v1/src/run.ts
+++ b/.github/actions/semantic-pr-footer-v1/src/run.ts
@@ -54,9 +54,9 @@ export default function run(core: Core, github: GitHub) {
     // Checked only after the single-line form fails, so nothing that passed
     // before changes behaviour. The section must have content: a bare heading
     // promising QA notes that never arrive is not a footer.
-    const headingIndex = bodyLines.findLastIndex(line =>
-      /^#{1,6}\s+\S/.test(line)
-    )
+const headingIndex = bodyLines.findLastIndex(line =>
+  /^\s{0,3}#{1,6}\s+\S/.test(line)
+)
     const heading = headingIndex === -1 ? '' : bodyLines[headingIndex]
     const sectionBody = bodyLines
       .slice(headingIndex + 1)


### PR DESCRIPTION
Lets QA notes be written as a trailing markdown section instead of only as an
inline last line.

## Why

`run.ts` reads a single line — the last non-empty one — and `isValidFooter`
requires a keyword followed by a suffix on that same line. So this fails:

```markdown
This PR does some things.

## QA Notes

Build the binary, then confirm it starts and writes a report.
```

The last line is the prose, not the heading; and even if the heading were last,
`^qa notes:? ` would reject it because of the leading `#`s and the missing
same-line suffix. In practice that pushes everyone toward a one-line footer even
when the QA plan is several sentences, and I have seen PR bodies end up with a
`## QA Notes` section for humans *plus* a redundant `QA notes: see above` line to
satisfy the check.

## What changes

**`isValidFooter` strips markdown before matching**, so a heading or emphasised
footer is recognised — `## QA Notes: verify X`, `**No QA required**`.

Only *leading* whitespace is trimmed. That detail matters: the prefix rule requires
whitespace after the keyword (`Closes:` alone is invalid, and there is a test for
it), so trimming the end would have made every prefixed footer fail. I broke all 28
existing cases on the first attempt exactly this way.

**`run.ts` falls back to the last markdown heading** when the final line is not
itself a valid footer, which is what allows the detail to live beneath the heading.

## Deliberately kept strict

The looser rule could easily become "a heading exists somewhere", which would check
nothing. So:

- **The section must have content.** A bare `## QA Notes` with nothing beneath it
  fails — a heading promising QA notes that never arrive is not a footer.
- **Only `qa notes` may stand alone.** Issue-linking keywords still need their
  reference on the same line, so `## Closes` with `#123` underneath fails.
- **Nothing previously accepted changes.** The single-line path runs first and is
  untouched; the section check is a fallback after it fails.

## Tests

54 passing, with `isValidFooter.ts` and `run.ts` both at 100% line, branch and
function coverage. New coverage: heading and emphasis forms; bare `qa notes` accepted only
as a section heading and rejected otherwise; issue-linking keywords rejected as bare
headings; trailing-section extraction with and without content; an unrelated
trailing section rejected; and a single-line footer still taking precedence when
both are present.

`dist` is rebuilt, since the action runs `dist/index.js`.

## Rollout note

Every consuming repo pins this action at `@main`, so merging takes effect
everywhere immediately. The change is additive by construction — no previously
valid footer becomes invalid — which is why I structured it as a fallback rather
than a rewrite of the matching rules.

No QA needed: CI configuration only, and this PR's own footer exercises the unchanged inline path while the new section path is covered by unit tests.
