### PR TITLE
chore(ci): ignore @types/node majors and align dependabot policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 
 updates:
   - package-ecosystem: 'github-actions'
+    rebase-strategy: disabled
     directories:
       - '/'
       # dependabot only checks for action.yml files in the root directory so we need to add a globstar to all our action directories so dependabot will update them correctly
@@ -22,6 +23,8 @@ updates:
       default-days: 7
 
   - package-ecosystem: 'npm'
+    rebase-strategy: disabled
+    versioning-strategy: 'increase-if-necessary'
     directory: '/'
     schedule:
       interval: 'monthly'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,11 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: 'chore'
+    ignore:
+      # Major must track the Node runtime we target (`engines.node`), not the latest release
+      - dependency-name: '@types/node'
+        update-types:
+          - 'version-update:semver-major'
     groups:
       eslint:
         patterns:


### PR DESCRIPTION
`@types/node`'s major version tracks the Node runtime it describes, so it should
follow this repo's target rather than the newest published release. `engines.node`
here is `>=24` and `package.json` pins `@types/node: ^24.0.0`. #413 proposed
bumping it to `26.0.0`, which would have put the type definitions two majors ahead
of the runtime we build and test against — the types would describe APIs that
aren't there. The ignore rule keeps the major pinned to the runtime while
minor/patch updates continue to flow through the `npm-low-risk` group.

Config updates to reduce rebasing when it is not necessary.


No QA Required
